### PR TITLE
Multiple changes for upcoming 3.22.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ DJANGO_SETTINGS_MODULE = tcms.settings.test
 python_files = tests.py tests/test_*.py
 
 # This magic value causes py.test does not collect arbitrary classes, like
-# Nitrate's TestCase, TestPlan, and TestRun, that are wrongly treated as tests.
+# Kiwi's TestCase, TestPlan, and TestRun, that are wrongly treated as tests.
 # This value lets py.test only collect classes that is derived from either
 # django.test.TestCase or unittest.TestCase
 # So, if anyone writes a test class with a name including this string, it is

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -479,13 +479,14 @@ def update(request):
     return say_yes()
 
 
+@require_POST
 def update_case_run_status(request):
     '''
     Update Case Run status.
     '''
     now = datetime.datetime.now()
 
-    data = request.REQUEST.copy()
+    data = request.POST.copy()
     ctype = data.get("content_type")
     vtype = data.get('value_type', 'str')
     object_pk_str = data.get("object_pk")

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -600,8 +600,8 @@ class TestCaseUpdateActions(ModelUpdateActions):
 
     def __init__(self, request):
         self.request = request
-        self.target_field = request.REQUEST.get('target_field')
-        self.new_value = request.REQUEST.get('new_value')
+        self.target_field = request.POST.get('target_field')
+        self.new_value = request.POST.get('new_value')
 
     def get_update_action(self):
         return getattr(self, '_update_%s' % self.target_field, None)
@@ -741,6 +741,7 @@ class TestCaseUpdateActions(ModelUpdateActions):
 
 # NOTE: what permission is necessary
 # FIXME: find a good chance to map all TestCase property change request to this
+@require_POST
 def update_cases_default_tester(request):
     '''Update default tester upon selected TestCases'''
     proxy = TestCaseUpdateActions(request)

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -106,7 +106,7 @@ def info(request):
 
             if self.request.GET.get('env_group_id'):
                 env_group = TCMSEnvGroup.objects.get(
-                    id=self.request.REQUEST['env_group_id']
+                    id=self.request.GET['env_group_id']
                 )
                 return env_group.property.all()
             else:

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -167,14 +167,15 @@ def info(request):
     return HttpResponse('Unrecognizable infotype')
 
 
+@require_GET
 def form(request):
     """Response get form ajax call, most using in dialog"""
 
     # The parameters in internal_parameters will delete from parameters
     internal_parameters = ['app_form', 'format']
-    parameters = strip_parameters(request.REQUEST, internal_parameters)
-    q_app_form = request.REQUEST.get('app_form')
-    q_format = request.REQUEST.get('format')
+    parameters = strip_parameters(request.GET, internal_parameters)
+    q_app_form = request.GET.get('app_form')
+    q_format = request.GET.get('format')
     if not q_format:
         q_format = 'p'
 

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -146,7 +146,7 @@ def info(request):
             return Version.objects.filter(product__id=self.product_id)
 
     objects = Objects(request=request, product_id=request.GET.get('product_id'))
-    obj = getattr(objects, request.GET['info_type'], None)
+    obj = getattr(objects, request.GET.get('info_type'), None)
 
     if obj:
         if request.GET.get('format') == 'ulli':

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -19,6 +19,7 @@ from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_POST
 
 from tcms.management.models import Component, TestBuild, Version
 from tcms.management.models import Priority
@@ -749,11 +750,12 @@ update_cases_sortkey = update_cases_default_tester
 update_cases_reviewer = update_cases_default_tester
 
 
+@require_POST
 def comment_case_runs(request):
-    '''
+    """
     Add comment to one or more caseruns at a time.
-    '''
-    data = request.REQUEST.copy()
+    """
+    data = request.POST.copy()
     comment = data.get('comment', None)
     if not comment:
         return say_no('Comments needed')

--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -374,6 +374,7 @@ def say_yes():
 
 
 # Deprecated. Not flexible.
+@require_POST
 def update(request):
     '''
     Generic approach to update a model,\n
@@ -381,7 +382,7 @@ def update(request):
     '''
     now = datetime.datetime.now()
 
-    data = request.REQUEST.copy()
+    data = request.POST.copy()
     ctype = data.get("content_type")
     vtype = data.get('value_type', 'str')
     object_pk_str = data.get("object_pk")

--- a/tcms/core/contrib/auth/forms.py
+++ b/tcms/core/contrib/auth/forms.py
@@ -45,7 +45,7 @@ class RegistrationForm(UserCreationForm):
         s = Site.objects.get_current()
         cu = '%s%s' % (
             request_host_link(request, s.domain),
-            reverse('tcms.core.contrib.auth.views.confirm',
+            reverse('tcms-confirm',
                     args=[active_key.activation_key, ])
         )
         mailto(

--- a/tcms/core/contrib/auth/tests.py
+++ b/tcms/core/contrib/auth/tests.py
@@ -132,7 +132,7 @@ class TestRegistration(TestCase):
                                      'email': 'new-tester@example.com'})
         self.assertContains(
             response,
-            '<a href="{}">Continue</a>'.format(reverse('tcms.core.views.index')),
+            '<a href="{}">Continue</a>'.format(reverse('core-views-index')),
             html=True)
 
         users = User.objects.filter(username=username)
@@ -204,7 +204,7 @@ class TestConfirm(TestCase):
 
         self.assertContains(
             response,
-            '<a href="{}">Continue</a>'.format(reverse('tcms.core.views.index')),
+            '<a href="{}">Continue</a>'.format(reverse('core-views-index')),
             html=True)
 
     def test_confirm(self):

--- a/tcms/core/contrib/auth/tests.py
+++ b/tcms/core/contrib/auth/tests.py
@@ -77,16 +77,16 @@ class TestLogout(TestCase):
         cls.tester = User.objects.create_user(username='authtester',
                                               email='authtester@example.com',
                                               password='password')
-        cls.logout_url = reverse('tcms.core.contrib.auth.views.logout')
+        cls.logout_url = reverse('tcms-logout')
 
     def test_logout_then_redirect_to_next(self):
         self.client.login(username=self.tester.username, password='password')
         response = self.client.get(self.logout_url, follow=True)
-        self.assertRedirects(response, reverse('django.contrib.auth.views.login'))
+        self.assertRedirects(response, reverse('tcms-login'))
 
     def test_logout_then_goto_next(self):
         self.client.login(username=self.tester.username, password='password')
-        next_url = reverse('tcms.testplans.views.all')
+        next_url = reverse('plans-all')
         response = self.client.get(self.logout_url, {'next': next_url}, follow=True)
         self.assertRedirects(response, next_url)
 
@@ -109,7 +109,7 @@ class MockThread(object):
 class TestRegistration(TestCase):
 
     def setUp(self):
-        self.register_url = reverse('tcms.core.contrib.auth.views.register')
+        self.register_url = reverse('tcms-register')
         self.fake_activate_key = 'secret-activate-key'
 
     def test_open_registration_page(self):
@@ -159,7 +159,7 @@ class TestRegistration(TestCase):
         # Verify notification mail
         self.assertEqual(1, len(mail.outbox))
         self.assertEqual(settings.EMAIL_FROM, mail.outbox[0].from_email)
-        self.assertIn(reverse('tcms.core.contrib.auth.views.confirm',
+        self.assertIn(reverse('tcms-confirm',
                               args=[self.fake_activate_key]),
                       mail.outbox[0].body)
 
@@ -194,7 +194,7 @@ class TestConfirm(TestCase):
                                            password='password')
 
     def test_fail_if_activation_key_not_exist(self):
-        confirm_url = reverse('tcms.core.contrib.auth.views.confirm',
+        confirm_url = reverse('tcms-confirm',
                               args=['nonexisting-activation-key'])
         response = self.client.get(confirm_url)
 
@@ -214,7 +214,7 @@ class TestConfirm(TestCase):
             sha1.return_value.hexdigest.return_value = fake_activate_key
             UserActivateKey.set_random_key_for_user(self.new_user)
 
-        confirm_url = reverse('tcms.core.contrib.auth.views.confirm',
+        confirm_url = reverse('tcms-confirm',
                               args=[fake_activate_key])
         response = self.client.get(confirm_url)
 
@@ -225,7 +225,7 @@ class TestConfirm(TestCase):
         self.assertContains(
             response,
             '<a href="{}">Continue</a>'.format(
-                reverse('tcms.profiles.views.redirect_to_profile')),
+                reverse('tcms-redirect_to_profile')),
             html=True)
 
         user = User.objects.get(username=self.new_user.username)

--- a/tcms/core/contrib/auth/views.py
+++ b/tcms/core/contrib/auth/views.py
@@ -112,5 +112,5 @@ def confirm(request, activation_key):
         info_type=Prompt.Info,
         info=msg,
         next=request.GET.get('next', reverse(
-            'tcms.profiles.views.redirect_to_profile'))
+            'tcms-redirect_to_profile'))
     ))

--- a/tcms/core/contrib/auth/views.py
+++ b/tcms/core/contrib/auth/views.py
@@ -19,7 +19,7 @@ from tcms.core.views import Prompt
 def logout(request):
     """Logout method of account"""
     auth.logout(request)
-    return redirect(request.GET.get('next', reverse('tcms.core.views.index')))
+    return redirect(request.GET.get('next', reverse('core-views-index')))
 
 
 @require_http_methods(['GET', 'POST'])
@@ -36,7 +36,7 @@ def register(request, template_name='registration/registration_form.html'):
             request=request,
             info_type=Prompt.Alert,
             info='The backend is not allowed to register.',
-            next=request_data.get('next', reverse('tcms.core.views.index'))
+            next=request_data.get('next', reverse('core-views-index'))
         ))
 
     if request.method == 'POST':
@@ -68,7 +68,7 @@ def register(request, template_name='registration/registration_form.html'):
                 request=request,
                 info_type=Prompt.Info,
                 info=msg,
-                next=request.POST.get('next', reverse('tcms.core.views.index'))
+                next=request.POST.get('next', reverse('core-views-index'))
             ))
     else:
         form = RegistrationForm()
@@ -94,7 +94,7 @@ def confirm(request, activation_key):
             request=request,
             info_type=Prompt.Info,
             info=msg,
-            next=request.GET.get('next', reverse('tcms.core.views.index'))
+            next=request.GET.get('next', reverse('core-views-index'))
         ))
 
     # All thing done, start to active the user and use the user login

--- a/tcms/core/files.py
+++ b/tcms/core/files.py
@@ -95,7 +95,7 @@ def upload_file(request):
             )
 
             return HttpResponseRedirect(
-                reverse('tcms.testplans.views.attachment',
+                reverse('plan-attachment',
                         args=[request.POST['to_plan_id']])
             )
         elif request.POST.get('to_case_id'):
@@ -105,18 +105,18 @@ def upload_file(request):
             )
 
             return HttpResponseRedirect(
-                reverse('tcms.testcases.views.attachment',
+                reverse('testcases-attachment',
                         args=[request.POST['to_case_id']])
             )
     else:
         try:
             return HttpResponseRedirect(
-                reverse('tcms.testplans.views.attachment',
+                reverse('plan-attachment',
                         args=[request.POST['to_plan_id']])
             )
         except KeyError:
             return HttpResponseRedirect(
-                reverse('tcms.testcases.views.attachment',
+                reverse('testcases-attachment',
                         args=[request.POST['to_case_id']])
             )
 

--- a/tcms/core/tests/test_files.py
+++ b/tcms/core/tests/test_files.py
@@ -41,7 +41,7 @@ class TestUploadFile(BasePlanCase):
         super(TestUploadFile, cls).setUpClass()
 
         cls.file_upload_dir = tempfile.mkdtemp(prefix='{0}-upload-dir'.format(cls.__name__))
-        cls.upload_file_url = reverse('tcms.core.files.upload_file')
+        cls.upload_file_url = reverse('mgmt-upload_file')
 
     @classmethod
     def tearDownClass(cls):
@@ -65,17 +65,17 @@ class TestUploadFile(BasePlanCase):
         super(TestUploadFile, self).tearDown()
 
     def test_no_file_is_posted(self):
-        response = self.client.post(reverse('tcms.core.files.upload_file'),
+        response = self.client.post(reverse('mgmt-upload_file'),
                                     {'to_plan_id': self.plan.pk})
         self.assertRedirects(
             response,
-            reverse('tcms.testplans.views.attachment', args=[self.plan.pk]))
+            reverse('plan-attachment', args=[self.plan.pk]))
 
-        response = self.client.post(reverse('tcms.core.files.upload_file'),
+        response = self.client.post(reverse('mgmt-upload_file'),
                                     {'to_case_id': self.case_1.pk})
         self.assertRedirects(
             response,
-            reverse('tcms.testcases.views.attachment', args=[self.case_1.pk]))
+            reverse('testcases-attachment', args=[self.case_1.pk]))
 
     @patch('tcms.core.files.settings.MAX_UPLOAD_SIZE', new=10)
     def test_refuse_if_file_is_too_big(self):
@@ -95,7 +95,7 @@ class TestUploadFile(BasePlanCase):
 
         self.assertRedirects(
             response,
-            reverse('tcms.testplans.views.attachment', args=[self.plan.pk]))
+            reverse('plan-attachment', args=[self.plan.pk]))
 
         attachments = list(TestAttachment.objects.filter(
             file_name=os.path.basename(self.upload_filename)))
@@ -117,7 +117,7 @@ class TestUploadFile(BasePlanCase):
 
         self.assertRedirects(
             response,
-            reverse('tcms.testcases.views.attachment', args=[self.case_1.pk]))
+            reverse('testcases-attachment', args=[self.case_1.pk]))
 
         attachments = list(TestAttachment.objects.filter(
             file_name=os.path.basename(self.upload_filename)))
@@ -153,40 +153,40 @@ class TestAbleToDeleteFile(BasePlanCase):
         self.request = RequestFactory()
 
     def test_superuser_can(self):
-        request = self.request.get(reverse('tcms.core.files.delete_file',
+        request = self.request.get(reverse('mgmt-delete_file',
                                            args=[self.fake_file_id]))
         request.user = self.superuser
         self.assertTrue(able_to_delete_attachment(request, self.fake_file_id))
 
     def test_attachment_submitter_can(self):
-        request = self.request.get(reverse('tcms.core.files.delete_file',
+        request = self.request.get(reverse('mgmt-delete_file',
                                            args=[self.fake_file_id]))
         request.user = self.attachment.submitter
         self.assertTrue(able_to_delete_attachment(request, self.fake_file_id))
 
     def test_plan_author_can(self):
-        request = self.request.get(reverse('tcms.core.files.delete_file',
+        request = self.request.get(reverse('mgmt-delete_file',
                                            args=[self.fake_file_id]),
                                    data={'from_plan': self.plan.pk})
         request.user = self.plan.author
         self.assertTrue(able_to_delete_attachment(request, self.fake_file_id))
 
     def test_plan_owner_can(self):
-        request = self.request.get(reverse('tcms.core.files.delete_file',
+        request = self.request.get(reverse('mgmt-delete_file',
                                            args=[self.fake_file_id]),
                                    data={'from_plan': self.plan.pk})
         request.user = self.plan.owner
         self.assertTrue(able_to_delete_attachment(request, self.fake_file_id))
 
     def test_case_owner_can(self):
-        request = self.request.get(reverse('tcms.core.files.delete_file',
+        request = self.request.get(reverse('mgmt-delete_file',
                                            args=[self.fake_file_id]),
                                    data={'from_case': self.case_1.pk})
         request.user = self.case_1.author
         self.assertTrue(able_to_delete_attachment(request, self.fake_file_id))
 
     def test_cannot_delete_by_others(self):
-        request = self.request.get(reverse('tcms.core.files.delete_file',
+        request = self.request.get(reverse('mgmt-delete_file',
                                            args=[self.fake_file_id]),
                                    data={'from_case': self.case_1.pk})
         request.user = self.anyone_else
@@ -230,7 +230,7 @@ class TestDeleteFileAuthorization(BasePlanCase):
         self.client.login(username=self.anyone_else.username,
                           password=self.anyone_else_pwd)
 
-        url = reverse('tcms.core.files.delete_file', args=[self.plan_attachment.pk])
+        url = reverse('mgmt-delete_file', args=[self.plan_attachment.pk])
         response = self.client.get(url, {'from_plan': self.plan.pk})
 
         self.assertEqual({'rc': 2, 'response': 'auth_failure'}, json.loads(response.content))
@@ -239,7 +239,7 @@ class TestDeleteFileAuthorization(BasePlanCase):
         self.client.login(username=self.plan_attachment.submitter.username,
                           password=self.submitter_pwd)
 
-        url = reverse('tcms.core.files.delete_file', args=[self.plan_attachment.pk])
+        url = reverse('mgmt-delete_file', args=[self.plan_attachment.pk])
         response = self.client.get(url, {'from_plan': self.plan.pk})
 
         self.assertEqual({'rc': 0, 'response': 'ok'}, json.loads(response.content))
@@ -252,7 +252,7 @@ class TestDeleteFileAuthorization(BasePlanCase):
         self.client.login(username=self.case_attachment.submitter.username,
                           password=self.submitter_pwd)
 
-        url = reverse('tcms.core.files.delete_file', args=[self.case_attachment.pk])
+        url = reverse('mgmt-delete_file', args=[self.case_attachment.pk])
         response = self.client.get(url, {'from_case': self.case_1.pk})
 
         self.assertEqual({'rc': 0, 'response': 'ok'}, json.loads(response.content))

--- a/tcms/core/tests/test_views.py
+++ b/tcms/core/tests/test_views.py
@@ -33,7 +33,7 @@ class TestQuickSearch(BaseCaseRun):
     def setUpTestData(cls):
         super(TestQuickSearch, cls).setUpTestData()
 
-        cls.search_url = reverse('tcms.core.views.search')
+        cls.search_url = reverse('core-views-search')
 
     def test_goto_plan(self):
         response = self.client.get(self.search_url,

--- a/tcms/core/tests/test_views.py
+++ b/tcms/core/tests/test_views.py
@@ -21,24 +21,10 @@ from tcms.testruns.models import TestCaseRunStatus
 from tcms.tests.factories import TCMSEnvGroupFactory
 from tcms.tests.factories import TCMSEnvGroupPropertyMapFactory
 from tcms.tests.factories import TCMSEnvPropertyFactory
-from tcms.tests.factories import TestCaseRunFactory
-from tcms.tests.factories import TestRunFactory
 from tcms.tests import BasePlanCase
+from tcms.tests import BaseCaseRun
 from tcms.tests import remove_perm_from_user
 from tcms.tests import user_should_have_perm
-
-
-class BaseCaseRun(BasePlanCase):
-    """Base test case containing test run and case runs"""
-
-    @classmethod
-    def setUpTestData(cls):
-        super(BaseCaseRun, cls).setUpTestData()
-
-        cls.test_run = TestRunFactory(plan=cls.plan)
-        cls.case_run_1 = TestCaseRunFactory(case=cls.case_1, run=cls.test_run)
-        cls.case_run_2 = TestCaseRunFactory(case=cls.case_2, run=cls.test_run)
-        cls.case_run_3 = TestCaseRunFactory(case=cls.case_3, run=cls.test_run)
 
 
 class TestQuickSearch(BaseCaseRun):

--- a/tcms/core/tests/test_views.py
+++ b/tcms/core/tests/test_views.py
@@ -2,12 +2,14 @@
 
 import json
 
-from django_comments.models import Comment
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django_comments.models import Comment
 from six.moves import http_client
 
+from tcms.testcases.forms import CaseAutomatedForm
 from tcms.testplans.models import TestPlan
 from tcms.testruns.models import TestCaseRun
 from tcms.testruns.models import TestCaseRunStatus
@@ -254,3 +256,13 @@ class TestUpdateCaseRunStatus(BaseCaseRun):
         self.assertEqual({'rc': 0, 'response': 'ok'}, json.loads(response.content))
         self.assertEqual(
             'PAUSED', TestCaseRun.objects.get(pk=self.case_run_1.pk).case_run_status.name)
+
+
+class TestGetForm(TestCase):
+    """Test case for form"""
+
+    def test_get_form(self):
+        response = self.client.get(reverse('tcms.core.ajax.form'),
+                                   {'app_form': 'testcases.CaseAutomatedForm'})
+        form = CaseAutomatedForm()
+        self.assertHTMLEqual(response.content, form.as_p())

--- a/tcms/core/tests/test_views.py
+++ b/tcms/core/tests/test_views.py
@@ -2,24 +2,30 @@
 
 import json
 
+from django_comments.models import Comment
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.core import serializers
 from django.core.urlresolvers import reverse
 from django import test
-from django_comments.models import Comment
 from six.moves import http_client
 
 from tcms.management.models import Priority
+from tcms.management.models import TCMSEnvGroup
+from tcms.management.models import TCMSEnvProperty
 from tcms.testcases.forms import CaseAutomatedForm
 from tcms.testcases.forms import TestCase
 from tcms.testplans.models import TestPlan
 from tcms.testruns.models import TestCaseRun
 from tcms.testruns.models import TestCaseRunStatus
+from tcms.tests.factories import TCMSEnvGroupFactory
+from tcms.tests.factories import TCMSEnvGroupPropertyMapFactory
+from tcms.tests.factories import TCMSEnvPropertyFactory
+from tcms.tests.factories import TestCaseRunFactory
+from tcms.tests.factories import TestRunFactory
 from tcms.tests import BasePlanCase
 from tcms.tests import remove_perm_from_user
 from tcms.tests import user_should_have_perm
-from tcms.tests.factories import TestCaseRunFactory
-from tcms.tests.factories import TestRunFactory
 
 
 class BaseCaseRun(BasePlanCase):
@@ -321,3 +327,50 @@ class TestUpdateCasePriority(BasePlanCase):
 
         for pk in (self.case_1.pk, self.case_3.pk):
             self.assertEqual('P3', TestCase.objects.get(pk=pk).priority.value)
+
+
+class TestGetObjectInfo(BasePlanCase):
+    """Test case for info view method"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TestGetObjectInfo, cls).setUpTestData()
+
+        cls.get_info_url = reverse('tcms.core.ajax.info')
+
+        cls.group_nitrate = TCMSEnvGroupFactory(name='nitrate')
+        cls.group_new = TCMSEnvGroupFactory(name='NewGroup')
+
+        cls.property_os = TCMSEnvPropertyFactory(name='os')
+        cls.property_python = TCMSEnvPropertyFactory(name='python')
+        cls.property_django = TCMSEnvPropertyFactory(name='django')
+
+        TCMSEnvGroupPropertyMapFactory(group=cls.group_nitrate,
+                                       property=cls.property_os)
+        TCMSEnvGroupPropertyMapFactory(group=cls.group_nitrate,
+                                       property=cls.property_python)
+        TCMSEnvGroupPropertyMapFactory(group=cls.group_new,
+                                       property=cls.property_django)
+
+    def test_get_env_properties(self):
+        response = self.client.get(self.get_info_url, {'info_type': 'env_properties'})
+
+        expected_json = json.loads(
+            serializers.serialize(
+                'json',
+                TCMSEnvProperty.objects.all(),
+                fields=('name', 'value')))
+        self.assertEqual(expected_json, json.loads(response.content))
+
+    def test_get_env_properties_by_group(self):
+        response = self.client.get(self.get_info_url,
+                                   {'info_type': 'env_properties',
+                                    'env_group_id': self.group_new.pk})
+
+        group = TCMSEnvGroup.objects.get(pk=self.group_new.pk)
+        expected_json = json.loads(
+            serializers.serialize(
+                'json',
+                group.property.all(),
+                fields=('name', 'value')))
+        self.assertEqual(expected_json, json.loads(response.content))

--- a/tcms/core/tests/test_views.py
+++ b/tcms/core/tests/test_views.py
@@ -40,7 +40,7 @@ class TestQuickSearch(BaseCaseRun):
                                    {'search_type': 'plans', 'search_content': self.plan.pk})
         self.assertRedirects(
             response,
-            reverse('tcms.testplans.views.get', args=[self.plan.pk]),
+            reverse('test_plan_url_short', args=[self.plan.pk]),
             target_status_code=http_client.MOVED_PERMANENTLY)
 
     def test_goto_case(self):
@@ -48,38 +48,38 @@ class TestQuickSearch(BaseCaseRun):
                                    {'search_type': 'cases', 'search_content': self.case_1.pk})
         self.assertRedirects(
             response,
-            reverse('tcms.testcases.views.get', args=[self.case_1.pk]))
+            reverse('testcases-get', args=[self.case_1.pk]))
 
     def test_goto_run(self):
         response = self.client.get(self.search_url,
                                    {'search_type': 'runs', 'search_content': self.test_run.pk})
         self.assertRedirects(
             response,
-            reverse('tcms.testruns.views.get', args=[self.test_run.pk]))
+            reverse('testruns-get', args=[self.test_run.pk]))
 
     def test_goto_plan_search(self):
         response = self.client.get(self.search_url,
                                    {'search_type': 'plans', 'search_content': 'keyword'})
-        url = '{}?a=search&search=keyword'.format(reverse('tcms.testplans.views.all'))
+        url = '{}?a=search&search=keyword'.format(reverse('plans-all'))
         self.assertRedirects(response, url)
 
     def test_goto_case_search(self):
         response = self.client.get(self.search_url,
                                    {'search_type': 'cases', 'search_content': 'keyword'})
-        url = '{}?a=search&search=keyword'.format(reverse('tcms.testcases.views.all'))
+        url = '{}?a=search&search=keyword'.format(reverse('testcases-all'))
         self.assertRedirects(response, url)
 
     def test_goto_run_search(self):
         response = self.client.get(self.search_url,
                                    {'search_type': 'runs', 'search_content': 'keyword'})
-        url = '{}?a=search&search=keyword'.format(reverse('tcms.testruns.views.all'))
+        url = '{}?a=search&search=keyword'.format(reverse('testruns-all'))
         self.assertRedirects(response, url)
 
     def test_goto_search_if_no_object_is_found(self):
         non_existing_pk = 9999999
         response = self.client.get(self.search_url,
                                    {'search_type': 'cases', 'search_content': non_existing_pk})
-        url = '{}?a=search&search={}'.format(reverse('tcms.testcases.views.all'), non_existing_pk)
+        url = '{}?a=search&search={}'.format(reverse('testcases-all'), non_existing_pk)
         self.assertRedirects(response, url)
 
     def test_404_if_unknown_search_type(self):
@@ -99,7 +99,7 @@ class TestCommentCaseRuns(BaseCaseRun):
                                               email='tester@example.com',
                                               password='password')
 
-        cls.many_comments_url = reverse('tcms.core.ajax.comment_case_runs')
+        cls.many_comments_url = reverse('ajax-comment_case_runs')
 
     def test_refuse_if_missing_comment(self):
         self.client.login(username=self.tester.username, password='password')
@@ -161,7 +161,7 @@ class TestUpdateObject(BasePlanCase):
         super(TestUpdateObject, cls).setUpTestData()
 
         cls.permission = 'testplans.change_testplan'
-        cls.update_url = reverse('tcms.core.ajax.update')
+        cls.update_url = reverse('ajax-update')
 
         cls.tester = User.objects.create_user(username='tester',
                                               email='tester@example.com',
@@ -212,7 +212,7 @@ class TestUpdateCaseRunStatus(BaseCaseRun):
         super(TestUpdateCaseRunStatus, cls).setUpTestData()
 
         cls.permission = 'testruns.change_testcaserun'
-        cls.update_url = reverse('tcms.core.ajax.update_case_run_status')
+        cls.update_url = reverse('ajax-update_case_run_status')
 
         cls.tester = User.objects.create_user(username='tester',
                                               email='tester@example.com',
@@ -256,7 +256,7 @@ class TestGetForm(test.TestCase):
     """Test case for form"""
 
     def test_get_form(self):
-        response = self.client.get(reverse('tcms.core.ajax.form'),
+        response = self.client.get(reverse('ajax-form'),
                                    {'app_form': 'testcases.CaseAutomatedForm'})
         form = CaseAutomatedForm()
         self.assertHTMLEqual(response.content, form.as_p())
@@ -270,7 +270,7 @@ class TestUpdateCasePriority(BasePlanCase):
         super(TestUpdateCasePriority, cls).setUpTestData()
 
         cls.permission = 'testcases.change_testcase'
-        cls.case_update_url = reverse('tcms.core.ajax.update_cases_default_tester')
+        cls.case_update_url = reverse('ajax-update_cases_default_tester')
         cls.tester = User.objects.create_user(username='tester',
                                               email='tester@example.com',
                                               password='password')
@@ -322,7 +322,7 @@ class TestGetObjectInfo(BasePlanCase):
     def setUpTestData(cls):
         super(TestGetObjectInfo, cls).setUpTestData()
 
-        cls.get_info_url = reverse('tcms.core.ajax.info')
+        cls.get_info_url = reverse('ajax-info')
 
         cls.group_nitrate = TCMSEnvGroupFactory(name='nitrate')
         cls.group_new = TCMSEnvGroupFactory(name='NewGroup')

--- a/tcms/core/views/index.py
+++ b/tcms/core/views/index.py
@@ -9,8 +9,8 @@ def index(request, template_name='index.html'):
     """
 
     if not request.user.is_authenticated():
-        return HttpResponseRedirect(reverse('django.contrib.auth.views.login'))
+        return HttpResponseRedirect(reverse('tcms-login'))
 
     return HttpResponseRedirect(
-        reverse('tcms.profiles.views.recent', args=[request.user.username])
+        reverse('tcms-recent', args=[request.user.username])
     )

--- a/tcms/core/views/search.py
+++ b/tcms/core/views/search.py
@@ -37,8 +37,8 @@ def search(request):
         objects = model.objects.filter(pk=pk).only('pk')
         if objects:
             return HttpResponseRedirect(
-                reverse('tcms.{}.views.get'.format(model._meta.app_label), args=[pk]))
+                reverse('{}-get'.format(model._meta.app_label), args=[pk]))
 
     url = '{}?a=search&search={}'.format(
-        reverse('tcms.{}.views.all'.format(model._meta.app_label)), search_content)
+        reverse('{}-all'.format(model._meta.app_label)), search_content)
     return HttpResponseRedirect(url)

--- a/tcms/issuetracker/bugzilla_integration.py
+++ b/tcms/issuetracker/bugzilla_integration.py
@@ -25,7 +25,7 @@ def _rpc_add_bug_to_bugzilla(rpc, testcase, bug):
     try:
         text = """---- Bug confirmed via test case ----
 URL: %s
-Summary: %s""" % (settings.KIWI_BASE_URL + reverse('tcms.testcases.views.get', args=[testcase.pk]),
+Summary: %s""" % (settings.KIWI_BASE_URL + reverse('testcases-get', args=[testcase.pk]),
                   testcase.summary)
 
         rpc.update_bugs(bug.bug_id, {'comment': {'comment': text, 'is_private': False}})

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -121,7 +121,7 @@ class Bugzilla(IssueTrackerType):
             effect = 'None'
 
         caserun_url = settings.KIWI_BASE_URL + \
-            reverse('tcms.testruns.views.get', args=[caserun.run.pk])
+            reverse('testruns-get', args=[caserun.run.pk])
 
         comment = "Filed from caserun %s\n\n" % caserun_url
         comment += "Version-Release number of selected " \

--- a/tcms/management/tests.py
+++ b/tcms/management/tests.py
@@ -34,7 +34,7 @@ class TestVisitAndSearchGroupPage(TestCase):
     def setUpTestData(cls):
         super(TestVisitAndSearchGroupPage, cls).setUpTestData()
 
-        cls.group_url = reverse('tcms.management.views.environment_groups')
+        cls.group_url = reverse('mgmt-environment_groups')
 
         cls.new_tester = User.objects.create_user(username='new-tester',
                                                   email='new-tester@example.com',
@@ -98,7 +98,7 @@ class TestVisitAndSearchGroupPage(TestCase):
         self.client.login(username=self.new_tester.username, password='password')
 
         user_should_have_perm(self.new_tester, 'management.change_tcmsenvgroup')
-        group_edit_url = reverse('tcms.management.views.environment_group_edit')
+        group_edit_url = reverse('mgmt-environment_group_edit')
 
         response = self.client.get(self.group_url)
 
@@ -130,7 +130,7 @@ class TestAddGroup(TestCase):
     def setUpTestData(cls):
         super(TestAddGroup, cls).setUpTestData()
 
-        cls.group_add_url = reverse('tcms.management.views.environment_groups')
+        cls.group_add_url = reverse('mgmt-environment_groups')
 
         cls.tester = User.objects.create_user(username='new-tester',
                                               email='new-tester@example.com',
@@ -203,7 +203,7 @@ class TestDeleteGroup(TestCase):
     def setUpTestData(cls):
         super(TestDeleteGroup, cls).setUpTestData()
 
-        cls.group_delete_url = reverse('tcms.management.views.environment_groups')
+        cls.group_delete_url = reverse('mgmt-environment_groups')
         cls.permission = 'management.delete_tcmsenvgroup'
 
         cls.tester = User.objects.create_user(username='tester',
@@ -274,7 +274,7 @@ class TestModifyGroup(TestCase):
         cls.group_nitrate = TCMSEnvGroupFactory(name='nitrate', manager=cls.tester)
 
         cls.permission = 'management.change_tcmsenvgroup'
-        cls.group_modify_url = reverse('tcms.management.views.environment_groups')
+        cls.group_modify_url = reverse('mgmt-environment_groups')
 
     def tearDown(self):
         remove_perm_from_user(self.tester, self.permission)
@@ -335,7 +335,7 @@ class TestVisitEnvironmentGroupPage(TestCase):
                                               password='password')
         user_should_have_perm(cls.tester, 'management.change_tcmsenvgroup')
 
-        cls.group_edit_url = reverse('tcms.management.views.environment_group_edit')
+        cls.group_edit_url = reverse('mgmt-environment_group_edit')
         cls.group_nitrate = TCMSEnvGroupFactory(name='nitrate', manager=cls.tester)
         cls.disabled_group = TCMSEnvGroupFactory(name='disabled-group',
                                                  is_active=False,
@@ -401,7 +401,7 @@ class TestEditEnvironmentGroup(TestCase):
         cls.property_2 = TCMSEnvPropertyFactory()
         cls.property_3 = TCMSEnvPropertyFactory()
 
-        cls.group_edit_url = reverse('tcms.management.views.environment_group_edit')
+        cls.group_edit_url = reverse('mgmt-environment_group_edit')
 
     def test_refuse_if_there_is_duplicate_group_name(self):
         self.client.login(username=self.tester.username, password='password')
@@ -444,7 +444,7 @@ class TestAddProperty(TestCase):
         super(TestAddProperty, cls).setUpTestData()
 
         cls.permission = 'management.add_tcmsenvproperty'
-        cls.group_properties_url = reverse('tcms.management.views.environment_properties')
+        cls.group_properties_url = reverse('mgmt-environment_properties')
 
         cls.tester = User.objects.create_user(username='tester',
                                               email='tester@example.com',
@@ -519,7 +519,7 @@ class TestEditProperty(TestCase):
         super(TestEditProperty, cls).setUpTestData()
 
         cls.permission = 'management.change_tcmsenvproperty'
-        cls.group_properties_url = reverse('tcms.management.views.environment_properties')
+        cls.group_properties_url = reverse('mgmt-environment_properties')
 
         cls.tester = User.objects.create_user(username='tester',
                                               email='tester@example.com',
@@ -579,7 +579,7 @@ class TestEnableDisableProperty(TestCase):
         super(TestEnableDisableProperty, cls).setUpTestData()
 
         cls.permission = 'management.change_tcmsenvproperty'
-        cls.group_properties_url = reverse('tcms.management.views.environment_properties')
+        cls.group_properties_url = reverse('mgmt-environment_properties')
 
         cls.tester = User.objects.create_user(username='tester',
                                               email='tester@example.com',
@@ -728,7 +728,7 @@ class ProductTests(TestCase):
             # create Test Plan via the UI by sending a POST request to the view
             previous_plans_count = TestPlan.objects.count()
             test_plan_name = 'Test plan for the new product'
-            response = self.c.post(reverse('tcms.testplans.views.new'), {
+            response = self.c.post(reverse('plans-new'), {
                 'name': test_plan_name,
                 'product': product.pk,
                 'product_version': product_version.pk,

--- a/tcms/profiles/tests.py
+++ b/tcms/profiles/tests.py
@@ -48,7 +48,7 @@ class TestOpenBookmarks(TestCase):
     def test_open_bookmark_page(self):
         self.client.login(username=self.tester.username, password='password')
 
-        url = reverse('tcms.profiles.views.bookmark',
+        url = reverse('tcms-bookmark',
                       kwargs={'username': self.tester.username})
         response = self.client.get(url)
 

--- a/tcms/profiles/urls.py
+++ b/tcms/profiles/urls.py
@@ -1,25 +1,26 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import include, url, patterns
+from django.conf.urls import include, url
+from django.contrib.auth import views as contrib_auth_views
 
-urlpatterns = patterns('tcms.profiles.views',
-    url(r'^profile/$', 'redirect_to_profile'),
-    url(r'^(?P<username>[\w.@+-]+)/profile/$', 'profile'),
-    url(r'^(?P<username>[\w.@+-]+)/bookmarks/$', 'bookmark'),
-    url(r'^(?P<username>[\w.@+-]+)/recent/$', 'recent'),
-)
+from . import views as profiles_views
+from tcms.core.contrib.auth import views as auth_views
 
-urlpatterns += patterns('tcms.core.contrib.auth.views',
-    url(r'logout/$', 'logout'),
-    url(r'register/$', 'register'),
-    url(r'confirm/(?P<activation_key>[A-Za-z0-9\-]+)/$', 'confirm'),
-)
+urlpatterns = [
+    url(r'^profile/$', profiles_views.redirect_to_profile),
+    url(r'^(?P<username>[\w.@+-]+)/profile/$', profiles_views.profile),
+    url(r'^(?P<username>[\w.@+-]+)/bookmarks/$', profiles_views.bookmark),
+    url(r'^(?P<username>[\w.@+-]+)/recent/$', profiles_views.recent),
 
-urlpatterns += patterns('django.contrib.auth.views',
-    url(r'login/$', 'login'),
-    url(r'changepassword/$', 'password_change'),
-    url(r'changepassword/done/$', 'password_change_done'),
-    url(r'^passwordreset/$', 'password_reset'),
-    url(r'^passwordreset/done/$', 'password_reset_done'),
-    url(r'^passwordreset/confirm//(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$', 'password_reset_confirm'),
-)
+    url(r'logout/$', auth_views.logout),
+    url(r'register/$', auth_views.register),
+    url(r'confirm/(?P<activation_key>[A-Za-z0-9\-]+)/$', auth_views.confirm),
+
+    url(r'login/$', contrib_auth_views.login),
+    url(r'changepassword/$', contrib_auth_views.password_change),
+    url(r'changepassword/done/$', contrib_auth_views.password_change_done),
+    url(r'^passwordreset/$', contrib_auth_views.password_reset),
+    url(r'^passwordreset/done/$', contrib_auth_views.password_reset_done),
+    url(r'^passwordreset/confirm//(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
+        contrib_auth_views.password_reset_confirm),
+]

--- a/tcms/profiles/urls.py
+++ b/tcms/profiles/urls.py
@@ -7,19 +7,23 @@ from . import views as profiles_views
 from tcms.core.contrib.auth import views as auth_views
 
 urlpatterns = [
-    url(r'^profile/$', profiles_views.redirect_to_profile),
-    url(r'^(?P<username>[\w.@+-]+)/profile/$', profiles_views.profile),
-    url(r'^(?P<username>[\w.@+-]+)/bookmarks/$', profiles_views.bookmark),
-    url(r'^(?P<username>[\w.@+-]+)/recent/$', profiles_views.recent),
+    url(r'^profile/$', profiles_views.redirect_to_profile, name='tcms-redirect_to_profile'),
+    url(r'^(?P<username>[\w.@+-]+)/profile/$', profiles_views.profile,
+        name='tcms-profile'),
+    url(r'^(?P<username>[\w.@+-]+)/bookmarks/$', profiles_views.bookmark,
+        name='tcms-bookmark'),
+    url(r'^(?P<username>[\w.@+-]+)/recent/$', profiles_views.recent,
+        name='tcms-recent'),
 
-    url(r'logout/$', auth_views.logout),
-    url(r'register/$', auth_views.register),
-    url(r'confirm/(?P<activation_key>[A-Za-z0-9\-]+)/$', auth_views.confirm),
+    url(r'logout/$', auth_views.logout, name='tcms-logout'),
+    url(r'register/$', auth_views.register, name='tcms-register'),
+    url(r'confirm/(?P<activation_key>[A-Za-z0-9\-]+)/$', auth_views.confirm,
+        name='tcms-confirm'),
 
-    url(r'login/$', contrib_auth_views.login),
+    url(r'login/$', contrib_auth_views.login, name='tcms-login'),
     url(r'changepassword/$', contrib_auth_views.password_change),
     url(r'changepassword/done/$', contrib_auth_views.password_change_done),
-    url(r'^passwordreset/$', contrib_auth_views.password_reset),
+    url(r'^passwordreset/$', contrib_auth_views.password_reset, name='tcms-password_reset'),
     url(r'^passwordreset/done/$', contrib_auth_views.password_reset_done),
     url(r'^passwordreset/confirm//(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
         contrib_auth_views.password_reset_confirm),

--- a/tcms/profiles/views.py
+++ b/tcms/profiles/views.py
@@ -33,7 +33,7 @@ def bookmark(request, username, template_name='profile/bookmarks.html'):
     """
 
     if username != request.user.username:
-        return http.HttpResponseRedirect(reverse('django.contrib.auth.views.login'))
+        return http.HttpResponseRedirect(reverse('tcms-login'))
     else:
         up = {'user': request.user}
 
@@ -117,7 +117,7 @@ def recent(request, username, template_name='profile/recent.html'):
     """List the recent plan/run"""
 
     if username != request.user.username:
-        return http.HttpResponseRedirect(reverse('django.contrib.auth.views.login'))
+        return http.HttpResponseRedirect(reverse('tcms-login'))
     else:
         up = {'user': request.user}
 
@@ -154,4 +154,4 @@ def recent(request, username, template_name='profile/recent.html'):
 @login_required
 def redirect_to_profile(request):
     return http.HttpResponseRedirect(
-        reverse('tcms.profiles.views.recent', args=[request.user.username]))
+        reverse('tcms-recent', args=[request.user.username]))

--- a/tcms/report/urls.py
+++ b/tcms/report/urls.py
@@ -7,7 +7,7 @@ from . import views
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='overall/', permanent=True)),
-    url(r'^overall/$', views.overall),
+    url(r'^overall/$', views.overall, name='report-overall'),
     url(r'^product/(?P<product_id>\d+)/overview/$', views.overview),
     url(r'^product/(?P<product_id>\d+)/build/$', views.ProductBuildReport.as_view(),
         name='report-overall-product-build'),

--- a/tcms/report/urls.py
+++ b/tcms/report/urls.py
@@ -1,30 +1,24 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.views.generic.base import RedirectView
 
-from .views import CustomDetailReport
-from .views import CustomReport
-from .views import ProductBuildReport
-from .views import ProductComponentReport
-from .views import ProductVersionReport
-from .views import TestingReport
-from .views import TestingReportCaseRuns
+from . import views
 
-urlpatterns = patterns('tcms.report.views',
+urlpatterns = [
     url(r'^$', RedirectView.as_view(url='overall/', permanent=True)),
-    url(r'^overall/$', 'overall'),
-    url(r'^product/(?P<product_id>\d+)/overview/$', 'overview'),
-    url(r'^product/(?P<product_id>\d+)/build/$', ProductBuildReport.as_view(),
+    url(r'^overall/$', views.overall),
+    url(r'^product/(?P<product_id>\d+)/overview/$', views.overview),
+    url(r'^product/(?P<product_id>\d+)/build/$', views.ProductBuildReport.as_view(),
         name='report-overall-product-build'),
-    url(r'^product/(?P<product_id>\d+)/version/$', ProductVersionReport.as_view(),
+    url(r'^product/(?P<product_id>\d+)/version/$', views.ProductVersionReport.as_view(),
         name='report-overall-product-version'),
-    url(r'^product/(?P<product_id>\d+)/component/$', ProductComponentReport.as_view(),
+    url(r'^product/(?P<product_id>\d+)/component/$', views.ProductComponentReport.as_view(),
         name='report-overall-product-component'),
-    url(r'custom/$', CustomReport.as_view(), name='report-custom'),
-    url(r'^custom/details/$', CustomDetailReport.as_view(), name='report-custom-details'),
+    url(r'custom/$', views.CustomReport.as_view(), name='report-custom'),
+    url(r'^custom/details/$', views.CustomDetailReport.as_view(), name='report-custom-details'),
 
-    url(r'^testing/$', TestingReport.as_view(), name='testing-report'),
-    url(r'^testing/case-runs/$', TestingReportCaseRuns.as_view(),
+    url(r'^testing/$', views.TestingReport.as_view(), name='testing-report'),
+    url(r'^testing/case-runs/$', views.TestingReportCaseRuns.as_view(),
         name='testing-report-case-runs'),
-)
+]

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -181,7 +181,7 @@ INSTALLED_APPS = (
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 
 TEMPLATE_CONTEXT_PROCESSORS = DEFAULT_SETTINGS.TEMPLATE_CONTEXT_PROCESSORS + (
-    'django.core.context_processors.request',
+    'django.template.context_processors.request',
     'tcms.core.context_processors.admin_prefix_processor',
     'tcms.core.context_processors.auth_backend_processor',
     'tcms.core.context_processors.request_contents_processor',
@@ -231,8 +231,8 @@ CACHES = {
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
-# Needed by django.core.context_processors.debug:
-# See http://docs.djangoproject.com/en/dev/ref/templates/api/#django-core-context-processors-debug
+# Needed by django.template.context_processors.debug:
+# See http://docs.djangoproject.com/en/dev/ref/templates/api/#django-template-context-processors-debug
 INTERNAL_IPS = ('127.0.0.1', )
 
 # Authentication backends

--- a/tcms/settings/devel.py
+++ b/tcms/settings/devel.py
@@ -27,10 +27,6 @@ INSTALLED_APPS += (
     'debug_toolbar',
 )
 
-DEBUG_TOOLBAR_CONFIG = {
-    'INTERCEPT_REDIRECTS': False
-}
-
 # For local development
 ENABLE_ASYNC_EMAIL = False
 

--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -1379,6 +1379,7 @@ function showCommentForm() {
       url: '/caserun/comment-many/',
       data: {'comment': comments, 'run': runs.join()},
       dataType: 'json',
+      type: 'post',
       success: function(res) {
         if (res.rc == 0) {
           reloadWindow();

--- a/tcms/templates/admin/base_site.html
+++ b/tcms/templates/admin/base_site.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block breadcrumbs %}
     <div class="sprites crumble">
-        <a href="{% url "tcms.core.views.index" %}">Home</a>
+        <a href="{% url "core-views-index" %}">Home</a>
         >> <a href="/admin/">Admin</a>
         >>{{ title }}
     </div>

--- a/tcms/templates/admin/change_form.html
+++ b/tcms/templates/admin/change_form.html
@@ -23,7 +23,7 @@
 {% block contents %}
 <div id="content-main">
      <div class="sprites crumble">
-        <a href="{% url "tcms.core.views.index" %}">Home</a>
+        <a href="{% url "core-views-index" %}">Home</a>
         >> <a href="/admin/">Admin</a>
         >>{{ title }}
     </div>

--- a/tcms/templates/admin/change_list.html
+++ b/tcms/templates/admin/change_list.html
@@ -14,7 +14,7 @@
 <div id="content-main">
 
     <div class="sprites crumble">
-        <a href="{% url "tcms.core.views.index" %}">Home</a>
+        <a href="{% url "core-views-index" %}">Home</a>
         >> <a href="/admin/">Admin</a>
         >>{{ title }}
     </div>

--- a/tcms/templates/admin/index.html
+++ b/tcms/templates/admin/index.html
@@ -12,7 +12,7 @@
 {% block contents %}
 <div id="content-main">
     <div class="sprites crumble">
-        <a href="{% url "tcms.core.views.index" %}">Home</a>
+        <a href="{% url "core-views-index" %}">Home</a>
         >> <a href="/admin/">Admin</a>
         >>{{ title }}
     </div>

--- a/tcms/templates/case/add_bug_form.html
+++ b/tcms/templates/case/add_bug_form.html
@@ -2,7 +2,7 @@
 	{% if perms.testcases.add_testcasebug %}
 	<tr>
 		<td colspan="4" style="padding:0;">
-			<form id="id_case_bug_form" action="{% url "tcms.testcases.views.bug" test_case.case_id %}" method="get">
+			<form id="id_case_bug_form" action="{% url "testcases-bug" test_case.case_id %}" method="get">
 				<div class="addtag">
 					<span class="tit">Add Bug</span>
 					<input type="hidden" name="handle" value="add" />

--- a/tcms/templates/case/all.html
+++ b/tcms/templates/case/all.html
@@ -23,7 +23,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.List.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a> >>
+		<a href="{% url "core-views-index" %}">Home</a> >>
 		{% if query_result %}
 		<a href="{% url "tcms.testcases.views.search" %}">Search Cases</a> >> Search result
 		{% else %}

--- a/tcms/templates/case/all.html
+++ b/tcms/templates/case/all.html
@@ -14,8 +14,8 @@
 <script type="text/javascript" src='{{ STATIC_URL }}js/testcase_actions.js'></script>
 <script type="text/javascript">
 	Nitrate.TestCases.List.Param = {
-		'case_printable': '{% url "tcms.testcases.views.printable" %}',
-		'case_export':'{% url "tcms.testcases.views.export" %}'
+		'case_printable': '{% url "testcases-printable" %}',
+		'case_export':'{% url "testcases-export" %}'
 	};
 Nitrate.Utils.after_page_load(Nitrate.TestCases.List.on_load);
 </script>
@@ -25,12 +25,12 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.List.on_load);
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a> >>
 		{% if query_result %}
-		<a href="{% url "tcms.testcases.views.search" %}">Search Cases</a> >> Search result
+		<a href="{% url "testcases-search" %}">Search Cases</a> >> Search result
 		{% else %}
 		Search Cases
 		{% endif %}
 	</div>
-	<form action="{% url "tcms.testcases.views.search" %}" method="get">
+	<form action="{% url "testcases-search" %}" method="get">
 		<div id="itemSearch" class="itemSearch">
 			<h2>Search Case</h2>
 			{% include "case/form/search.html" %}

--- a/tcms/templates/case/attachment.html
+++ b/tcms/templates/case/attachment.html
@@ -23,7 +23,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a> 
+		<a href="{% url "core-views-index" %}">Home</a> 
 		{% if testplan %}
 		>>Plan: <a href="{{ test_plan.get_absolute_url }}">[{{ testplan.plan_id}}]: {{ testplan.name }}</a> 
         >>Case: <a href="{% url "tcms.testcases.views.get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">[{{ testcase.case_id }}]: {{ testcase.summary }}</a> 

--- a/tcms/templates/case/attachment.html
+++ b/tcms/templates/case/attachment.html
@@ -26,15 +26,15 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 		<a href="{% url "core-views-index" %}">Home</a> 
 		{% if testplan %}
 		>>Plan: <a href="{{ test_plan.get_absolute_url }}">[{{ testplan.plan_id}}]: {{ testplan.name }}</a> 
-        >>Case: <a href="{% url "tcms.testcases.views.get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">[{{ testcase.case_id }}]: {{ testcase.summary }}</a> 
+        >>Case: <a href="{% url "testcases-get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">[{{ testcase.case_id }}]: {{ testcase.summary }}</a> 
 		{% else %}
-		>>Case: <a href="{% url "tcms.testcases.views.get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">[{{ testcase.case_id }}]: {{ testcase.summary }}</a> 
+		>>Case: <a href="{% url "testcases-get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">[{{ testcase.case_id }}]: {{ testcase.summary }}</a> 
         {% endif %}
 		>> Manage Attachment
 	</div>
 	<h2>{{ testcase.summary }}</h2>
 	<div class="Detailform border-1">
-		<form action="{% url "tcms.core.files.upload_file" %}" method="POST" enctype="multipart/form-data" >
+		<form action="{% url "mgmt-upload_file" %}" method="POST" enctype="multipart/form-data" >
 			<div class="mixbar">
 				<span class="tit">Upload New Attachment</span>
 				<input type="hidden" name="to_case_id" value="{{ testcase.case_id }}" />
@@ -59,11 +59,11 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 			<tbody>
 				{% for attachment in testcase.attachment.all %}
 				<tr id="{{ attachment.attachment_id }}" class="{% cycle 'odd' 'even' %}">
-					<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
+					<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
 					<td>{{ attachment.submitter }}</td>
 					<td>{{ attachment.create_date }}</td>
 					<td>{{ attachment.mime_type }}</td>
-					<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">View</a> | <a href="#" class="js-del-attach" data-params='[{{ attachment.attachment_id }}, "from_case", {{ testcase.case_id }}]'>Delete</a></td>
+					<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">View</a> | <a href="#" class="js-del-attach" data-params='[{{ attachment.attachment_id }}, "from_case", {{ testcase.case_id }}]'>Delete</a></td>
 				</tr>
 				{% endfor %}
 			</tbody>

--- a/tcms/templates/case/clone.html
+++ b/tcms/templates/case/clone.html
@@ -11,7 +11,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Clone.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if test_plan %}
 		>>Plan: <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		{% else %}

--- a/tcms/templates/case/clone.html
+++ b/tcms/templates/case/clone.html
@@ -15,7 +15,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Clone.on_load);
 		{% if test_plan %}
 		>>Plan: <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		{% else %}
-		>> <a href="{% url "tcms.testcases.views.search" %}">Search Cases</a>
+		>> <a href="{% url "testcases-search" %}">Search Cases</a>
 		{% endif %}
 		>> Clone case
 	</div>
@@ -39,7 +39,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Clone.on_load);
 					<input type="radio" id="id_use_filterplan" checked="checked"  name="selectplan"/>
 					<label for="id_use_filterplan" class="strong">Filter another plan</label>
 					<div id="id_filterPlan">
-					<form id="id_form_search_plan" action="{% url "tcms.testplans.views.all" %}" method="get">
+					<form id="id_form_search_plan" action="{% url "plans-all" %}" method="get">
 						<input type="hidden" name="action" value="clone_case" />
 						{% include 'plan/form/filter.html' %}
 						<div class="cell" style=" margin-left:0">
@@ -52,7 +52,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Clone.on_load);
 				{% endif %}
 				</div>
 			</div>
-			<form id="id_clone_form" action="{% url "tcms.testcases.views.clone" %}" method="post">
+			<form id="id_clone_form" action="{% url "testcases-clone" %}" method="post">
 				{{ form.case_id }}
 				<div class="listinfo">
 					<label class="strong title"></label>

--- a/tcms/templates/case/common/case_advance_filtered.html
+++ b/tcms/templates/case/common/case_advance_filtered.html
@@ -1,7 +1,7 @@
 {% load pagination_tags %}
 {% if test_cases %}
 	{% autopaginate test_cases %}
-	<form id="cases_form" action="{% url "tcms.testcases.views.clone" %}" method="post">
+	<form id="cases_form" action="{% url "testcases-clone" %}" method="post">
 	<div id="contentTab" class="mixbar">
 		{#}<span class="tit">{{ test_cases.count }} Cases</span>{#}
 		<span>
@@ -44,10 +44,10 @@
 					<img class="expand blind_icon" src="{{ STATIC_URL }}images/t1.gif" border="0" alt="">
 				</td>
 				<td valign="top"><input type="checkbox" name="case" value="{{ test_case.case_id }}"></td>
-				<td valign="top"><a href="{% url "tcms.testcases.views.get" test_case.case_id %}">{{ test_case.case_id }}</a></td>
-				<td valign="top" class="expandable"><a id="link_{{ test_case.case_id }}" href="{% url "tcms.testcases.views.get" test_case.case_id %}">{{ test_case.summary }}</a></td>
-				<td valign="top"><a href="{% url "tcms.profiles.views.profile" test_case.author.username %}">{{ test_case.author }}</a></td>
-				<td valign="top">{% if test_case.default_tester_id %}<a href="{% url "tcms.profiles.views.profile" test_case.default_tester.username %}">{{ test_case.default_tester }}</a>{% else %}None{% endif %}</td>
+				<td valign="top"><a href="{% url "testcases-get" test_case.case_id %}">{{ test_case.case_id }}</a></td>
+				<td valign="top" class="expandable"><a id="link_{{ test_case.case_id }}" href="{% url "testcases-get" test_case.case_id %}">{{ test_case.summary }}</a></td>
+				<td valign="top"><a href="{% url "tcms-profile" test_case.author.username %}">{{ test_case.author }}</a></td>
+				<td valign="top">{% if test_case.default_tester_id %}<a href="{% url "tcms-profile" test_case.default_tester.username %}">{{ test_case.default_tester }}</a>{% else %}None{% endif %}</td>
 				<td valign="top">{{ test_case.get_is_automated_status }}</td>
 				<td valign="top">{{ test_case.case_status }}</td>
 				<td valign="top">{{ test_case.category }}</td>

--- a/tcms/templates/case/common/case_filtered.html
+++ b/tcms/templates/case/common/case_filtered.html
@@ -1,4 +1,4 @@
-<form id="cases_form" action="{% url "tcms.testcases.views.clone" %}" method="post">
+<form id="cases_form" action="{% url "testcases-clone" %}" method="post">
 	<div id="contentTab" class="mixbar">
 		{#}<span class="tit">{{ test_cases.count }} Cases</span>{#}
 		<span>

--- a/tcms/templates/case/common/json_cases.txt
+++ b/tcms/templates/case/common/json_cases.txt
@@ -7,11 +7,11 @@
         [
             "<img class='expand blind_icon' src='{{ STATIC_URL }}images/t1.gif' border='0' alt=''>",
             "<input type='checkbox' name='case' value='{{ test_case.case_id }}'>",
-            "<a href='{% url "tcms.testcases.views.get" test_case.case_id %}'>{{ test_case.case_id }}</a>",
-            "<a id='link_{{ test_case.case_id }}' href='{% url "tcms.testcases.views.get" test_case.case_id %}'>{{ test_case.summary }}</a>",
-            "<a href='{% url "tcms.profiles.views.profile" test_case.author.username %}'>{{ test_case.author }}</a>",
+            "<a href='{% url "testcases-get" test_case.case_id %}'>{{ test_case.case_id }}</a>",
+            "<a id='link_{{ test_case.case_id }}' href='{% url "testcases-get" test_case.case_id %}'>{{ test_case.summary }}</a>",
+            "<a href='{% url "tcms-profile" test_case.author.username %}'>{{ test_case.author }}</a>",
             {% if test_case.default_tester_id %}
-                "<a href='{% url "tcms.profiles.views.profile" test_case.default_tester.username %}'>{{ test_case.default_tester }}</a>"
+                "<a href='{% url "tcms-profile" test_case.default_tester.username %}'>{{ test_case.default_tester }}</a>"
             {% else %}
                 "None"
             {% endif %},

--- a/tcms/templates/case/edit.html
+++ b/tcms/templates/case/edit.html
@@ -39,7 +39,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Edit.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if test_plan %}
 		>>Plan: <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		>>Case: <a href="{% url "tcms.testcases.views.get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.case_id }}: {{ test_case }}</a>

--- a/tcms/templates/case/edit.html
+++ b/tcms/templates/case/edit.html
@@ -42,16 +42,16 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Edit.on_load);
 		<a href="{% url "core-views-index" %}">Home</a>
 		{% if test_plan %}
 		>>Plan: <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
-		>>Case: <a href="{% url "tcms.testcases.views.get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.case_id }}: {{ test_case }}</a>
+		>>Case: <a href="{% url "testcases-get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.case_id }}: {{ test_case }}</a>
 		{% else %}
-		>> Case:<a href="{% url "tcms.testcases.views.get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.case_id }}: {{ test_case }}</a>
+		>> Case:<a href="{% url "testcases-get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.case_id }}: {{ test_case }}</a>
 		{% endif %}
 		>> Edit
 	</div>
   
 	
 	<span class="right-action">
-		<a href="{% url "tcms.testcases.views.text_history" test_case.case_id %}?from_plan={{ test_plan.plan_id }}" class="historylink">
+		<a href="{% url "testcases-text_history" test_case.case_id %}?from_plan={{ test_plan.plan_id }}" class="historylink">
 			Edit History
 		</a>
 	</span>

--- a/tcms/templates/case/get.html
+++ b/tcms/templates/case/get.html
@@ -46,7 +46,7 @@ Nitrate.TestCases.Instance = {
 	{% else %}
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		&gt;&gt; <a href="{% url "tcms.testcases.views.search" %}">Search Case</a>
+		&gt;&gt; <a href="{% url "testcases-search" %}">Search Case</a>
 		&gt;&gt; Case: {{ test_case.case_id }}: {{ test_case.summary }}
 	</div>
 	<div id="tcms_values" class="hidden">
@@ -58,7 +58,7 @@ Nitrate.TestCases.Instance = {
 		<span id="id_buttons" ><input id="btn_edit" type="button" value="Edit" data-link="{% url "tcms.testcases.views.edit" test_case.case_id %}?from_plan={{ test_plan.plan_id }}"/></span>
 		{% endif %}
 		{% if perms.testcases.add_testcaseplan %}
-		<span id=""><input type="button" id="btn_clone" value="Clone case" data-link="{% url "tcms.testcases.views.clone" %}?from_plan={{ test_plan.plan_id }}&case={{ test_case.case_id }}"/></span>
+		<span id=""><input type="button" id="btn_clone" value="Clone case" data-link="{% url "testcases-clone" %}?from_plan={{ test_plan.plan_id }}&case={{ test_case.case_id }}"/></span>
 		{% endif %}
 		{% if test_plan %}
 		<span class="right-action">
@@ -75,7 +75,7 @@ Nitrate.TestCases.Instance = {
 					<div class="title grey">Default Tester&nbsp;:</div>
 					<div class="name">
 						{% if test_case.default_tester	%}
-						<span id="display_default_tester"><a href="{% url "tcms.profiles.views.profile" test_case.default_tester.username %}">{{ test_case.default_tester.email }}</a></span>
+						<span id="display_default_tester"><a href="{% url "tcms-profile" test_case.default_tester.username %}">{{ test_case.default_tester.email }}</a></span>
 						{% else %}
 						<span >No default tester</span>
 						{% endif %}
@@ -117,7 +117,7 @@ Nitrate.TestCases.Instance = {
 				<div class="listinfo">
 					<div class="title grey">Author&nbsp;:</div>
 					<span class="name">
-						<a href="{% url "tcms.profiles.views.profile" test_case.author.username %}">
+						<a href="{% url "tcms-profile" test_case.author.username %}">
 							{{ test_case.author.email }}
 						</a>
 					</span>

--- a/tcms/templates/case/get.html
+++ b/tcms/templates/case/get.html
@@ -39,13 +39,13 @@ Nitrate.TestCases.Instance = {
 		<input id="id_case_id" type="hidden" name="case_id" value="{{ test_case.case_id }}" />
 	</div>
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> Plan: <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}:{{ test_plan.name }}</a> 
 		>>Case: {{ test_case.case_id }}: {{ test_case.summary }}
 	</div>
 	{% else %}
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt; <a href="{% url "tcms.testcases.views.search" %}">Search Case</a>
 		&gt;&gt; Case: {{ test_case.case_id }}: {{ test_case.summary }}
 	</div>

--- a/tcms/templates/case/get_attachment.html
+++ b/tcms/templates/case/get_attachment.html
@@ -11,11 +11,11 @@
 			<tbody>
 				{% for attachment in test_case.attachment.all %}
 				<tr id="{{ attachment.attachment_id }}" class="{% cycle 'odd' 'even' %}">
-					<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
+					<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
 					<td>{{ attachment.submitter }}</td>
 					<td>{{ attachment.create_date }}</td>
 					<td>{{ attachment.mime_type }}</td>
-					<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">View</a> | <a class="js-del-button" data-params='{"attachmentId": {{ attachment.attachment_id }}, "source": "from_case", "sourceId": {{ test_case.case_id }}}' href="#">Delete</a></td>
+					<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">View</a> | <a class="js-del-button" data-params='{"attachmentId": {{ attachment.attachment_id }}, "source": "from_case", "sourceId": {{ test_case.case_id }}}' href="#">Delete</a></td>
 				</tr>
 				 {% empty %}
 				 <tr><td colspan="5" align="center"><span class="grey">No attachments</span></td></tr>
@@ -25,7 +25,7 @@
 					<td colspan="5" style="padding:0;">
 						<div class="addtag">
 							<span class="tit">Add attachment</span>
-							<a href="{% url "tcms.testcases.views.attachment" test_case.case_id %}?from_plan={{ test_plan.plan_id }}" class="addlink">add</a> 
+							<a href="{% url "testcases-attachment" test_case.case_id %}?from_plan={{ test_plan.plan_id }}" class="addlink">add</a> 
 						</div>
 					</td>
 				</tr>

--- a/tcms/templates/case/get_bug.html
+++ b/tcms/templates/case/get_bug.html
@@ -13,7 +13,7 @@
 	{% for bug in test_case.get_bugs %}
 	<tr class="{% cycle 'even' 'odd' %}">
 		<td>{{ bug.case_run_id }}</td>
-		<td>{% if bug.case_run_id %}<a href="{% url "tcms.testruns.views.get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>{% else %}None{% endif %}</td>
+		<td>{% if bug.case_run_id %}<a href="{% url "testruns-get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>{% else %}None{% endif %}</td>
 		<td><a href="{{ bug.get_absolute_url }}">{{ bug.get_absolute_url }}</a></td>
         <td>
 			{% if perms.testcases.delete_testcasebug %}

--- a/tcms/templates/case/get_case_runs_by_plan.html
+++ b/tcms/templates/case/get_case_runs_by_plan.html
@@ -26,24 +26,24 @@
 				<input type="hidden" name="case_text_version" value="{{ test_case_run.case_text_version }}" />
 			</td>
 			<td class="expandable">
-				<a href="{% url "tcms.testcases.views.get" test_case_run.case_id %}?from_plan={{ test_case_run.run__plan_id }}">{{ test_case_run.pk }}</a>
+				<a href="{% url "testcases-get" test_case_run.case_id %}?from_plan={{ test_case_run.run__plan_id }}">{{ test_case_run.pk }}</a>
 			</td>
 			<td>
-				<a href="{% url "tcms.testruns.views.get" test_case_run.run_id %}">{{ test_case_run.run_id }}</a>
+				<a href="{% url "testruns-get" test_case_run.run_id %}">{{ test_case_run.run_id }}</a>
 			</td>
 			<td class="expandable">
 				<p>{{ test_case_run.run__summary }}</p>
 			</td>
 			<td>
 				{% if test_case_run.tested_by__username %}
-				<a href="{% url "tcms.profiles.views.profile" test_case_run.tested_by__username %}">{{ test_case_run.tested_by__username }}</a>
+				<a href="{% url "tcms-profile" test_case_run.tested_by__username %}">{{ test_case_run.tested_by__username }}</a>
 				{% else %}
 				<label>None</label>
 				{% endif %}
 			</td>
 			<td>
 				{% if test_case_run.assignee__username %}
-				<a href="{% url "tcms.profiles.views.profile" test_case_run.assignee__username %}">{{ test_case_run.assignee__username }}</a>
+				<a href="{% url "tcms-profile" test_case_run.assignee__username %}">{{ test_case_run.assignee__username }}</a>
 				{% else%}
 				None
 				{% endif %}

--- a/tcms/templates/case/get_component.html
+++ b/tcms/templates/case/get_component.html
@@ -1,4 +1,4 @@
-<form id="id_form_case_component" action="{% url "tcms.testcases.views.component" %}">
+<form id="id_form_case_component" action="{% url "testcases-component" %}">
 	<table class="list" cellspacing="0" cellspan="0" width="100%">
 		<thead>
 			<tr>

--- a/tcms/templates/case/get_details.html
+++ b/tcms/templates/case/get_details.html
@@ -16,7 +16,7 @@
 				<ul class="ul-no-format">
 					{% for attachment_file in attachments %}
 					<li>
-						<a href="{% url "tcms.core.files.check_file" attachment_file.attachment_id %}">
+						<a href="{% url "mgmt-check_file" attachment_file.attachment_id %}">
 							{{ attachment_file.file_name }}
 						</a>
 					</li>
@@ -47,7 +47,7 @@
 						<a href="{{ bug.get_absolute_url }}">{{ bug }}</a>
 						{% if bug.case_run_id %}
 						<span class="grey"> - From Run</span>
-						<a href="{% url "tcms.testruns.views.get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>
+						<a href="{% url "testruns-get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>
 						{% endif %}
 					</li>
 					{% empty %}

--- a/tcms/templates/case/get_details_case_run.html
+++ b/tcms/templates/case/get_details_case_run.html
@@ -96,13 +96,13 @@
 								<td>
 								{% for bug in bugs %}
 								    {% if bug.case_run_id %}
-								        <span class="grey">From Run</span><a href="{% url "tcms.testruns.views.get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>
+								        <span class="grey">From Run</span><a href="{% url "testruns-get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>
 								        {% if bug.case_run_id == test_case_run.pk and perms.testcases.delete_testcasebug %}
 								        <a href="javascript:void(0);" title="Remove This Bug" class="js-remove-caserun-bug" data-params='[{{ test_case_run.run.pk }}, "{{ bug.bug_id }}", {{ test_case_run.case_id }}, {{ test_case_run.pk }}]'><img width="9" height="9" title="remove this bug" src="{{ STATIC_URL }}images/remove_small.png"></a>
 								        {% endif %}
 								    {% else %}
 								        <span class="grey">From Case</span>
-								        <a href="{% url "tcms.testcases.views.get" bug.case_id %}">{{ bug.case_id }}</a>
+								        <a href="{% url "testcases-get" bug.case_id %}">{{ bug.case_id }}</a>
 								    {% endif %}
 								{% endfor %}
 								</td>
@@ -170,14 +170,14 @@
 								Attachment
 								<span>[
 								{% if perms.management.add_testattachment %}
-								<a href="{% url "tcms.testcases.views.attachment" test_case_run.case_id %}?from_plan={{ testrun.plan_id }}" target="_blank">Add</a>
+								<a href="{% url "testcases-attachment" test_case_run.case_id %}?from_plan={{ testrun.plan_id }}" target="_blank">Add</a>
 								{% endif %}
 								]</span>
 							</h4>
 							<ul class="ul-no-format">
 								{% for attachment_file in test_case.attachment.all %}
 								<li>
-									<a href="{% url "tcms.core.files.check_file" attachment_file.attachment_id %}">
+									<a href="{% url "mgmt-check_file" attachment_file.attachment_id %}">
 										{{ attachment_file.file_name }}
 									</a>
 								</li>

--- a/tcms/templates/case/get_details_review.html
+++ b/tcms/templates/case/get_details_review.html
@@ -15,7 +15,7 @@
 				<ul class="ul-no-format">
 					{% for attachment_file in attachments %}
 					<li>
-						<a href="{% url "tcms.core.files.check_file" attachment_file.attachment_id %}">
+						<a href="{% url "mgmt-check_file" attachment_file.attachment_id %}">
 							{{ attachment_file.file_name }}
 						</a>
 					</li>
@@ -46,7 +46,7 @@
 						<a href="{{ bug.get_absolute_url }}">{{ bug }}</a>
 						{% if bug.case_run_id %}
 						<span class="grey"> - From Run</span>
-						<a href="{% url "tcms.testruns.views.get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>
+						<a href="{% url "testruns-get" bug.case_run.run_id %}">{{ bug.case_run.run_id }}</a>
 						{% endif %}
 					</li>
 					{% empty %}

--- a/tcms/templates/case/get_text.html
+++ b/tcms/templates/case/get_text.html
@@ -2,7 +2,7 @@
 	<tr>
 		<td colspan="2">
 			<span class="right-bar">
-				<a href="{% url "tcms.testcases.views.text_history" test_case.case_id %}?from_plan={{ testplan.plan_id }}" class="historylink">
+				<a href="{% url "testcases-text_history" test_case.case_id %}?from_plan={{ testplan.plan_id }}" class="historylink">
 					View edit history(Current in version {{ test_case_text.case_text_version }})
 				</a>
 			</span>

--- a/tcms/templates/case/history.html
+++ b/tcms/templates/case/history.html
@@ -18,7 +18,7 @@
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">...</a>
 		{% if testplan %}
 		&gt;&gt; <a href="{{ test_plan.get_absolute_url }}">{{ testplan.plan_id }}: {{ testplan.name }}</a>

--- a/tcms/templates/case/history.html
+++ b/tcms/templates/case/history.html
@@ -10,7 +10,7 @@
 <script type="text/javascript">
 	jQ('.js-one-record').live('click',function() {
 		var param = jQ(this).data('param');
-		window.location.href='{% url "tcms.testcases.views.text_history" testcase.case_id %}?from_plan={{ testplan.plan_id }}&case_text_version=' + param;
+		window.location.href='{% url "testcases-text_history" testcase.case_id %}?from_plan={{ testplan.plan_id }}&case_text_version=' + param;
   });
 </script>
 {% endblock %}
@@ -19,11 +19,11 @@
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">...</a>
+		&gt;&gt; <a href="{% url "plans-all" %}">...</a>
 		{% if testplan %}
 		&gt;&gt; <a href="{{ test_plan.get_absolute_url }}">{{ testplan.plan_id }}: {{ testplan.name }}</a>
 		{% endif %}
-		&gt;&gt; <a href="{% url "tcms.testcases.views.get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">{{ testcase.case_id }}: {{ testcase.summary }}</a>
+		&gt;&gt; <a href="{% url "testcases-get" testcase.case_id %}?from_plan={{ testplan.plan_id }}">{{ testcase.case_id }}: {{ testcase.summary }}</a>
 		&gt;&gt; View edit history
 	</div>
 	<h2>Test Case History</h2>
@@ -36,7 +36,7 @@
 		</tr>
 		{% for text in test_case_texts %}
 		<tr class="{% cycle 'odd' 'even' %} js-one-record" data-param="{{ text.case_text_version }}">
-			<td><a href="{% url "tcms.testcases.views.text_history" testcase.case_id %}?from_plan={{ testplan.plan_id }}&case_text_version={{ text.case_text_version }}">{{ text.case_text_version }}</a></td>
+			<td><a href="{% url "testcases-text_history" testcase.case_id %}?from_plan={{ testplan.plan_id }}&case_text_version={{ text.case_text_version }}">{{ text.case_text_version }}</a></td>
 			<td>{{ text.create_date }}</td>
 			<td>{{ text.author__email }}</td>
 		</tr>

--- a/tcms/templates/case/new.html
+++ b/tcms/templates/case/new.html
@@ -25,7 +25,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Create.on_load);
 <!--add new case -->
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if test_plan %}
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.name }}</a>

--- a/tcms/templates/case/new.html
+++ b/tcms/templates/case/new.html
@@ -27,14 +27,14 @@ Nitrate.Utils.after_page_load(Nitrate.TestCases.Create.on_load);
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
 		{% if test_plan %}
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.name }}</a>
 		{% else %}
-		>> <a href="{% url "tcms.testcases.views.search" %}">Testing</a>
+		>> <a href="{% url "testcases-search" %}">Testing</a>
 		{% endif %}
 		>> Create new case
 	</div>
-	<form action="{% url "tcms.testcases.views.new" %}{% if test_plan %}?from_plan={{ test_plan.plan_id }}{% endif %}" method="POST">
+	<form action="{% url "testcases-new" %}{% if test_plan %}?from_plan={{ test_plan.plan_id }}{% endif %}" method="POST">
 		{% if test_plan %}
 		<input type="hidden" name="from_plan" value="{{ test_plan.plan_id }}" />
 		{% endif %}

--- a/tcms/templates/environment/group_edit.html
+++ b/tcms/templates/environment/group_edit.html
@@ -28,7 +28,7 @@ Nitrate.Utils.after_page_load(Nitrate.Management.Environment.Edit.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.management.views.environment_groups" %}">Environment groups</a>
 		>> Edit group - {{ environment.name }}
 	</div>

--- a/tcms/templates/environment/group_edit.html
+++ b/tcms/templates/environment/group_edit.html
@@ -29,10 +29,10 @@ Nitrate.Utils.after_page_load(Nitrate.Management.Environment.Edit.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.management.views.environment_groups" %}">Environment groups</a>
+		>> <a href="{% url "mgmt-environment_groups" %}">Environment groups</a>
 		>> Edit group - {{ environment.name }}
 	</div>
-	<form id="js-edit-group" action="{% url "tcms.management.views.environment_group_edit" %}" method="GET">
+	<form id="js-edit-group" action="{% url "mgmt-environment_group_edit" %}" method="GET">
 		<input type="hidden" name="action" value="modify">
 		<input type="hidden" name="id" value="{{ environment.id }}">
 		<h2>Edit Environment Group</h2>
@@ -51,7 +51,7 @@ Nitrate.Utils.after_page_load(Nitrate.Management.Environment.Edit.on_load);
 				<td class="manage-tit">
 					<label>
 						Properties<br />
-						<a class="editlink" href="{% url "tcms.management.views.environment_properties" %}">Edit</a>
+						<a class="editlink" href="{% url "mgmt-environment_properties" %}">Edit</a>
 					</label>
 				</td>
 				<td>

--- a/tcms/templates/environment/groups.html
+++ b/tcms/templates/environment/groups.html
@@ -9,9 +9,9 @@
 <script type="text/javascript" src="{{ STATIC_URL }}js/management_actions.js"></script>
 <script type="text/javascript">
 	Nitrate.Management.Environment.Param = {
-		'add_group': '{% url "tcms.management.views.environment_groups" %}',
-		'edit_group': '{% url "tcms.management.views.environment_group_edit" %}',
-		'delete_group': '{% url "tcms.management.views.environment_groups" %}'
+		'add_group': '{% url "mgmt-environment_groups" %}',
+		'edit_group': '{% url "mgmt-environment_group_edit" %}',
+		'delete_group': '{% url "mgmt-environment_groups" %}'
 	};
 
 	Nitrate.Utils.after_page_load(Nitrate.Management.Environment.on_load);
@@ -26,7 +26,7 @@
 		>> Environment Groups
 	</div>
 	<div class="mixbar">
-		<form method="get" action="{% url "tcms.management.views.environment_groups" %}" id="changelist-search">
+		<form method="get" action="{% url "mgmt-environment_groups" %}" id="changelist-search">
 			<input type="hidden" name="action" value="search">
             <label for="searchbar"><img alt="Search" height="20px" src="{{ STATIC_URL }}images/search.png"/></label>
 			<input type="text" id="searchbar" value="{{ REQUEST_CONTENTS.name }}" name="name" size="40"/>
@@ -55,7 +55,7 @@
 				<th align="center" height="26px">
 					<label class=" {% if env.is_active %}{% else %}disable line-through{% endif %}">
 						{% if perms.management.change_tcmsenvgroup %}
-						<a href="{% url "tcms.management.views.environment_group_edit" %}?id={{ env.id }}" >
+						<a href="{% url "mgmt-environment_group_edit" %}?id={{ env.id }}" >
 							{{ env.name }}
 						</a>
 						{% else %}
@@ -78,7 +78,7 @@
 				</td>
 				<td align="center">
 					{% if perms.management.change_tcmsenvgroup %}
-					<a href="{% url "tcms.management.views.environment_group_edit" %}?id={{ env.id }}" class="editlink">Edit</a>
+					<a href="{% url "mgmt-environment_group_edit" %}?id={{ env.id }}" class="editlink">Edit</a>
 					<a href="?id={{ env.id }}&action=modify&status=0" class="disablelink {% if env.is_active %}{% else %}hidden{% endif %}">Disable</a>
 					<a href="?id={{ env.id }}&action=modify&status=1" class="enablelink {% if env.is_active %}hidden{% endif %} ">Enable</a>
 					<a href="#" class="editlink js-del-env-group">Delete</a>

--- a/tcms/templates/environment/groups.html
+++ b/tcms/templates/environment/groups.html
@@ -22,7 +22,7 @@
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a> 
+		<a href="{% url "core-views-index" %}">Home</a> 
 		>> Environment Groups
 	</div>
 	<div class="mixbar">

--- a/tcms/templates/environment/property.html
+++ b/tcms/templates/environment/property.html
@@ -10,12 +10,12 @@
 <script type="text/javascript" src="{{ STATIC_URL }}js/management_actions.js"></script>
 <script type="text/javascript">
 	Nitrate.Management.Environment.Property.Param = {
-		'add_property': '{% url "tcms.management.views.environment_properties" %}',
-		'edit_property': '{% url "tcms.management.views.environment_properties" %}',
-		'del_property': '{% url "tcms.management.views.environment_properties" %}',
-		'modify_property': '{% url "tcms.management.views.environment_properties" %}',
-		'list_property_values': '{% url "tcms.management.views.environment_property_values" %}',
-		'add_property_value': '{% url "tcms.management.views.environment_property_values" %}'
+		'add_property': '{% url "mgmt-environment_properties" %}',
+		'edit_property': '{% url "mgmt-environment_properties" %}',
+		'del_property': '{% url "mgmt-environment_properties" %}',
+		'modify_property': '{% url "mgmt-environment_properties" %}',
+		'list_property_values': '{% url "mgmt-environment_property_values" %}',
+		'add_property_value': '{% url "mgmt-environment_property_values" %}'
 	};
 	Nitrate.Utils.after_page_load(Nitrate.Management.Environment.Property.on_load);
 </script>
@@ -25,7 +25,7 @@
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a> 
-		>> <a href="{% url "tcms.management.views.environment_groups" %}">Environment groups</a>
+		>> <a href="{% url "mgmt-environment_groups" %}">Environment groups</a>
 		>> Environment Properties
 	</div>
 	<h2>Environment Properties</h2>

--- a/tcms/templates/environment/property.html
+++ b/tcms/templates/environment/property.html
@@ -24,7 +24,7 @@
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a> 
+		<a href="{% url "core-views-index" %}">Home</a> 
 		>> <a href="{% url "tcms.management.views.environment_groups" %}">Environment groups</a>
 		>> Environment Properties
 	</div>

--- a/tcms/templates/management/get_tag.html
+++ b/tcms/templates/management/get_tag.html
@@ -13,9 +13,9 @@
 			{% for tag in tags %}
 			<tr class="{% cycle 'even' 'odd'%} js-one-tag" data-param="{{ tag }}">
 				<td><span class="tagvalue">{{ tag }}</span></td>
-				<td><a href="{% url "tcms.testplans.views.all" %}?action=search&tag__name__in={{ tag }}" title="{{ tag.num_plans }} plans tagged {{ tag }}">{{ tag.num_plans }}</a></td>
-				<td><a href="{% url "tcms.testcases.views.search" %}?a=search&tag__name__in={{ tag }}"  title="{{ tag.num_cases }} cases tagged {{ tag }}">{{ tag.num_cases }}</a></td>
-				<td><a href="{% url "tcms.testruns.views.all" %}?action=search&tag__name__in={{ tag }}"  title="{{ tag.num_runs }} runs tagged {{ tag }}">{{ tag.num_runs }}</a></td>
+				<td><a href="{% url "plans-all" %}?action=search&tag__name__in={{ tag }}" title="{{ tag.num_plans }} plans tagged {{ tag }}">{{ tag.num_plans }}</a></td>
+				<td><a href="{% url "testcases-search" %}?a=search&tag__name__in={{ tag }}"  title="{{ tag.num_cases }} cases tagged {{ tag }}">{{ tag.num_cases }}</a></td>
+				<td><a href="{% url "testruns-all" %}?action=search&tag__name__in={{ tag }}"  title="{{ tag.num_runs }} runs tagged {{ tag }}">{{ tag.num_runs }}</a></td>
 				{% if object.plan_id and perms.testplans.delete_testplantag %}
 				<td><a href="#tag" class="remove js-remove-tag" title="remmove tag from this plan" >Remove</a>
 				<a href="#tag" class="edit js-edit-tag" title="edit tag" >Edit</a>

--- a/tcms/templates/menu.html
+++ b/tcms/templates/menu.html
@@ -6,63 +6,63 @@
 		</li>
 		<li class="sprites menuline"></li>
 		<li class="nav_li{% ifequal module 'testplans' %} current{% endifequal %}">
-			<a href="{% url "tcms.testplans.views.all" %}">{% trans "PLANNING" %}</a>
+			<a href="{% url "plans-all" %}">{% trans "PLANNING" %}</a>
 			<ul class="nav_sub sub_plan" style="display: none;">
 				<li {% ifequal sub_module 'plans' %} class="subcurrent"{% endifequal %} >
-					<a href="{% url "tcms.testplans.views.all" %}">Search Plans</a>
+					<a href="{% url "plans-all" %}">Search Plans</a>
 				</li>
 				{% if user.is_authenticated %}
 				<li {% ifequal sub_module 'my_plans' %} class="subcurrent"{% endifequal %} >
-					<a href="{% url "tcms.testplans.views.all" %}?author__email__startswith={{ user.email }}">My Plans</a>
+					<a href="{% url "plans-all" %}?author__email__startswith={{ user.email }}">My Plans</a>
 				</li>
 				{% endif %}
 				{% if perms.testplans.add_testplan %}
 				<li {% ifequal sub_module 'new_plan' %} class="subcurrent"{% endifequal %} >
-					<a href="{% url "tcms.testplans.views.new" %}">New Plan</a>
+					<a href="{% url "plans-new" %}">New Plan</a>
 				</li>
 				{% endif %}
 			</ul>
 		</li>
 		<li class="sprites menuline"></li>
 		<li class="nav_li{% ifequal module 'testruns' %} current{% endifequal %}">
-			<a href="{% url "tcms.testruns.views.all" %}">{% trans "TESTING" %}</a>
+			<a href="{% url "testruns-all" %}">{% trans "TESTING" %}</a>
 			<ul id="submenu_test" class="nav_sub" style="display:none;">
 				<li {% ifequal sub_module 'runs' %} class="subcurrent"{% endifequal %} >
-					<a href="{% url "tcms.testruns.views.all" %}">Search Runs</a>
+					<a href="{% url "testruns-all" %}">Search Runs</a>
 				</li>
 				<li {% ifequal sub_module 'cases' %} class="subcurrent"{% endifequal %} >
-					<a href="{% url "tcms.testcases.views.search" %}">Search Cases</a>
+					<a href="{% url "testcases-search" %}">Search Cases</a>
 				</li>
 				{% if user.is_authenticated %}
 				<li {% ifequal sub_module 'my_runs' %} class="subcurrent"{% endifequal %} >
-					<a href="{% url "tcms.testruns.views.all" %}?people={{ user.email }}">My Runs</a>
+					<a href="{% url "testruns-all" %}?people={{ user.email }}">My Runs</a>
 				</li>
 				{% endif %}
 				{% if perms.testcases.add_testcase %}
 				<li>
-					<a href="{% url "tcms.testcases.views.new" %}">New Case</a>
+					<a href="{% url "testcases-new" %}">New Case</a>
 				</li>
 				{% endif %}
 			</ul>
 		</li>
 		<li class="sprites menuline"></li>
 		<li class="nav_li{% ifequal module 'env' %} current{% endifequal %} ">
-			<a href="{% url "tcms.management.views.environment_groups" %}">{% trans "ENVIRONMENT" %}</a>
+			<a href="{% url "mgmt-environment_groups" %}">{% trans "ENVIRONMENT" %}</a>
 			<ul	 id="submenu_environment" class="nav_sub"  style="display:none;">
 				<li>
-					<a href="{% url "tcms.management.views.environment_groups" %}">Groups</a>
+					<a href="{% url "mgmt-environment_groups" %}">Groups</a>
 				</li>
 				<li>
-					<a href="{% url "tcms.management.views.environment_properties" %}">Properties</a>
+					<a href="{% url "mgmt-environment_properties" %}">Properties</a>
 				</li>
 			</ul>
 		</li>
 		<li class="sprites menuline"></li>
 		<li class="nav_li {% ifequal module 'report' %} current{% endifequal %}">
-		<a href="{% url "tcms.report.views.overall" %}">{% trans "REPORTING" %}</a>
+		<a href="{% url "report-overall" %}">{% trans "REPORTING" %}</a>
 			<ul	 id="submenu_report" class="nav_sub"  style="display:none;">
 				<li>
-					<a href="{% url "tcms.report.views.overall" %}">Overall</a>
+					<a href="{% url "report-overall" %}">Overall</a>
 				</li>
 				<li>
 					<a href="{% url "report-custom" %}">Custom</a>

--- a/tcms/templates/menu.html
+++ b/tcms/templates/menu.html
@@ -2,7 +2,7 @@
 <div class="sprites menu">
 	<ul id="nav">
 		<li class="nav_li {% ifequal module 'index' %} current {% endifequal %}">
-			<a href="{% url "tcms.core.views.index" %}">{% trans "HOME" %}</a>
+			<a href="{% url "core-views-index" %}">{% trans "HOME" %}</a>
 		</li>
 		<li class="sprites menuline"></li>
 		<li class="nav_li{% ifequal module 'testplans' %} current{% endifequal %}">
@@ -103,7 +103,7 @@
 		{% endif %}
 	</ul>
 	<div class="right-action">
-		<form action="{% url "tcms.core.views.search" %}" method="get">
+		<form action="{% url "core-views-search" %}" method="get">
 			<span>
 				<select id="search_type" name="search_type">
 					<option value="plans"{% ifequal module 'testplans' %} selected{% endifequal %}>Test Plan</option>

--- a/tcms/templates/plan/all.html
+++ b/tcms/templates/plan/all.html
@@ -26,7 +26,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.List.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if query_result %}
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a> 
 		>> Search result

--- a/tcms/templates/plan/all.html
+++ b/tcms/templates/plan/all.html
@@ -28,14 +28,14 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.List.on_load);
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
 		{% if query_result %}
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a> 
+		>> <a href="{% url "plans-all" %}">Planning</a> 
 		>> Search result
 		{% else %}
 		>> Planning
 		{% endif %}
 	</div>
 	<div id="itemSearch" class="itemSearch">
-		<form id="id_search_plan_form" action="{% url "tcms.testplans.views.all" %}" method="get">
+		<form id="id_search_plan_form" action="{% url "plans-all" %}" method="get">
 			<input type="hidden" name="action" value="search" />
 			<h2>Search Plan</h2>
 			{% include 'plan/form/search.html' %}

--- a/tcms/templates/plan/attachment.html
+++ b/tcms/templates/plan/attachment.html
@@ -23,7 +23,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.name }}</a>
 		>> Add Attachment

--- a/tcms/templates/plan/attachment.html
+++ b/tcms/templates/plan/attachment.html
@@ -24,7 +24,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.name }}</a>
 		>> Add Attachment
 	</div>
@@ -33,7 +33,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 		<h2 id="display_title" style="line-height:1.2em;">{{ test_plan.name }}</h2>
 		</div><!-- plan detail end-->
 			<div class="Detailform border-1">
-			<form action="{% url "tcms.core.files.upload_file" %}" method="POST" enctype="multipart/form-data">
+			<form action="{% url "mgmt-upload_file" %}" method="POST" enctype="multipart/form-data">
 				<div class="mixbar">
 					<span class="tit">Upload New Attachment</span>
 					<input type="hidden" name="to_plan_id" value="{{ test_plan.plan_id }}" />
@@ -59,11 +59,11 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Attachment.on_load);
 				<tbody>
 					{% for attachment in test_plan.attachment.all %}
 					<tr id="{{ attachment.attachment_id }}"  class="{% cycle 'odd' 'even' %}">
-						<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
+						<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
 						<td>{{ attachment.submitter }}</td>
 						<td>{{ attachment.create_date }}</td>
 						<td>{{ attachment.mime_type }}</td>
-                        <td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">View</a> | <a class="js-del-attach" data-params='[{{attachment.attachment_id}}, "from_plan",{{test_plan.plan_id}}]' href="#">Delete</a> </td>
+                        <td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">View</a> | <a class="js-del-attach" data-params='[{{attachment.attachment_id}}, "from_plan",{{test_plan.plan_id}}]' href="#">Delete</a> </td>
                     </tr>
 					{% endfor %}
 				</tbody>

--- a/tcms/templates/plan/cases_rows.html
+++ b/tcms/templates/plan/cases_rows.html
@@ -19,17 +19,17 @@ test_cases should be a queryset of a list of TestCases.
 		class="checkbox case_selector" {% if not selected_case_ids or test_case.pk in selected_case_ids %}checked{% endif %} />
 	</td>
 	<td>
-		<a href="{% url "tcms.testcases.views.get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.pk }}</a>
+		<a href="{% url "testcases-get" test_case.case_id %}?from_plan={{ test_plan.plan_id }}">{{ test_case.pk }}</a>
 	</td>
 	<td class="subject expandable">
 		<a class="blind_down_link">{{ test_case.summary }}</a>
 	</td>
-	<td class="col_author_content"><a href="{% url "tcms.profiles.views.profile" test_case.author.username %}">{{ test_case.author }}</a></td>
+	<td class="col_author_content"><a href="{% url "tcms-profile" test_case.author.username %}">{{ test_case.author }}</a></td>
 	<td class="col_author_content">
 		{% if test_case.case_status.name == 'CONFIRMED' %} {# Show default tester when confirmed. #}
-			{% if test_case.default_tester_id %}<a href="{% url "tcms.profiles.views.profile" test_case.default_tester.username %}">{% endif %}{{ test_case.default_tester }}{% if test_case.default_tester_id %}</a>{% endif %}
+			{% if test_case.default_tester_id %}<a href="{% url "tcms-profile" test_case.default_tester.username %}">{% endif %}{{ test_case.default_tester }}{% if test_case.default_tester_id %}</a>{% endif %}
 		{% else %} {# Show reviewer when not confirmed. #}
-			{% if test_case.reviewer_id %}<a href="{% url "tcms.profiles.views.profile" test_case.reviewer.username %}">{% endif %}{{ test_case.reviewer }}{% if test_case.reviewer_id %}</a>{% endif %}</td>
+			{% if test_case.reviewer_id %}<a href="{% url "tcms-profile" test_case.reviewer.username %}">{% endif %}{{ test_case.reviewer }}{% if test_case.reviewer_id %}</a>{% endif %}</td>
 		{% endif %}
 	</td>
 	<td class="col_tester_content expandable">{{ test_case.get_is_automated_status }}</td>

--- a/tcms/templates/plan/choose_testrun.html
+++ b/tcms/templates/plan/choose_testrun.html
@@ -19,7 +19,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">...</a>
 		&gt;&gt; <a href="{{ plan.get_absolute_url }}">[{{plan.plan_id}}]{{ plan.name }}</a>
 		&gt;&gt; Add test case to runs

--- a/tcms/templates/plan/choose_testrun.html
+++ b/tcms/templates/plan/choose_testrun.html
@@ -20,7 +20,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">...</a>
+		&gt;&gt; <a href="{% url "plans-all" %}">...</a>
 		&gt;&gt; <a href="{{ plan.get_absolute_url }}">[{{plan.plan_id}}]{{ plan.name }}</a>
 		&gt;&gt; Add test case to runs
 	</div>
@@ -45,13 +45,13 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 						<input type="checkbox" name="run"  value="{{ test_run.pk }}"/>
 					</td>
 					<td>
-						<a href="{% url "tcms.testruns.views.get" test_run.pk %}">{{ test_run.pk }}</a>
+						<a href="{% url "testruns-get" test_run.pk %}">{{ test_run.pk }}</a>
 					</td>
 					<td >
 						{{ test_run.summary }}
 					</td>
 					<td>{{ test_run.build__name }}</td>
-					<td><a href="{% url "tcms.profiles.views.profile" test_run.manager__username %}">{{ test_run.manager__username }}</a></td>
+					<td><a href="{% url "tcms-profile" test_run.manager__username %}">{{ test_run.manager__username }}</a></td>
 					<td>{{ plan.name }}</td>
 				</tr>
 				{% empty %}
@@ -101,7 +101,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 							</a>
 						</td>
 						<td>
-							<a href="{% url "tcms.testcases.views.get" test_case.pk %}">{{ test_case.pk }}</a>
+							<a href="{% url "testcases-get" test_case.pk %}">{{ test_case.pk }}</a>
 							<input type="hidden" name="case" value="{{ test_case.pk }}">
 						</td>
 						<td class="js-one-case" data-param="{{ forloop.counter }}">
@@ -109,7 +109,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 								{{ test_case.summary }}
 							</a>
 						</td>
-						<td><a href="{% url "tcms.profiles.views.profile" test_case.author__username %}">{{ test_case.author__username }}</a></td>
+						<td><a href="{% url "tcms-profile" test_case.author__username %}">{{ test_case.author__username }}</a></td>
 						<td>{{ test_case.create_date }}</td>
 						<td>{{ test_case.category__name }}</td>
 						<td>{{ test_case.priority__value }}</td>

--- a/tcms/templates/plan/clone.html
+++ b/tcms/templates/plan/clone.html
@@ -17,7 +17,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Clone.on_load);
 
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		{% ifequal testplans|length 1 %}
 		>> <a href="{{ testplans.0.get_absolute_url }}">{{ testplans.0.plan_id }}: {{ testplans.0.name }}</a> 

--- a/tcms/templates/plan/clone.html
+++ b/tcms/templates/plan/clone.html
@@ -18,7 +18,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Clone.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		{% ifequal testplans|length 1 %}
 		>> <a href="{{ testplans.0.get_absolute_url }}">{{ testplans.0.plan_id }}: {{ testplans.0.name }}</a> 
 		>> Clone Plan
@@ -31,7 +31,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Clone.on_load);
 		select different product 
 	</p>
 	<div class="Detailform border-1">
-		<form action="{% url "tcms.testplans.views.clone" %}" method="post">
+		<form action="{% url "plans-clone" %}" method="post">
 			{% for testplan in testplans %}
 			<input type="hidden" name="plan" value="{{ testplan.pk }}" />
 			{% endfor %}

--- a/tcms/templates/plan/common/json_plan_runs.txt
+++ b/tcms/templates/plan/common/json_plan_runs.txt
@@ -6,11 +6,11 @@
 		{% for run in runs %}
 		[
 			"<input type='checkbox' name='run' value='{{ run.pk }}' class='run_selector'>",
-			"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{ run.run_id }}</a>",
-			"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{ run.summary }}</a>",
-			"<a href='{% url "tcms.profiles.views.profile" run.manager.username %}'>{{ run.manager }}</a>",
+			"<a href='{% url "testruns-get" run.run_id %}' >{{ run.run_id }}</a>",
+			"<a href='{% url "testruns-get" run.run_id %}' >{{ run.summary }}</a>",
+			"<a href='{% url "tcms-profile" run.manager.username %}'>{{ run.manager }}</a>",
 			{% if run.default_tester_id %}
-				"<a href='{% url "tcms.profiles.views.profile" run.default_tester.username %}'>{{ run.default_tester }}</a>"
+				"<a href='{% url "tcms-profile" run.default_tester.username %}'>{{ run.default_tester }}</a>"
 			{% else %}
 				"{{ run.default_tester }}"
 			{% endif %},

--- a/tcms/templates/plan/common/json_plans.txt
+++ b/tcms/templates/plan/common/json_plans.txt
@@ -10,9 +10,9 @@
         "0":"<input type='checkbox' name='plan' value='{{ test_plan.pk }}' title='Select/Unselect'>",
         "1":"<a href='{{ test_plan.get_absolute_url }}'>{{ test_plan.plan_id }}</a>",
         "2":"<a href='{{ test_plan.get_absolute_url }}' title='Go to {{ test_plan.name }}'>{{ test_plan }} </a>",
-        "3":"<a href='{% url "tcms.profiles.views.profile" test_plan.author.username %}'>{{ test_plan.author }}</a>",
+        "3":"<a href='{% url "tcms-profile" test_plan.author.username %}'>{{ test_plan.author }}</a>",
         {% if test_plan.owner %}
-            "4":"<a href='{% url "tcms.profiles.views.profile" test_plan.owner.username %}'>{{ test_plan.owner }}</a>"
+            "4":"<a href='{% url "tcms-profile" test_plan.owner.username %}'>{{ test_plan.owner }}</a>"
         {% else %}
             "4":"No owner"
         {% endif %},
@@ -22,7 +22,7 @@
         "8":"<a href='{{ test_plan.get_absolute_url }}' title='{{ test_plan.cal_cases_count }} test cases'>{{ test_plan.cal_cases_count }}</a>",
         "9":"<a href='{{ test_plan.get_absolute_url }}#testruns' title='{{ test_plan.cal_runs_count }} test runs'>{{ test_plan.cal_runs_count }}</a>",
         {% if perms.testplans.change_testplan %}
-            "10":"<a class='editlink' href='{% url "tcms.testplans.views.edit" test_plan.plan_id %}'>Edit</a>"
+            "10":"<a class='editlink' href='{% url "plan-edit" test_plan.plan_id %}'>Edit</a>"
         {% else %}
             "10":""
         {% endif %}

--- a/tcms/templates/plan/common/plans_advance_filtered.html
+++ b/tcms/templates/plan/common/plans_advance_filtered.html
@@ -6,14 +6,14 @@
 		{#<span class="tit">{{ test_plans.count }} Plans</span>#}
 		<span>
 			{% if perms.testplans.add_testplan %}
-			<input type="button" title="Create new test plan" value="New Test Plan" class="js-new-plan" data-param="{% url 'tcms.testplans.views.new' %}" />
-			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plan" data-param="{% url 'tcms.testplans.views.clone' %}" />
+			<input type="button" title="Create new test plan" value="New Test Plan" class="js-new-plan" data-param="{% url 'plans-new' %}" />
+			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plan" data-param="{% url 'plans-clone' %}" />
 			{% endif %}
 			<input type="button" value="Printable copy"
                    id="plan_advance_printable"
                    disabled="disabled" title="Create the printable copy for selected plans."
-                   data-param="{% url 'tcms.testplans.views.printable' %}" />
-			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-cases" data-param="{% url 'tcms.testplans.views.export' %}" />
+                   data-param="{% url 'plans-printable' %}" />
+			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-cases" data-param="{% url 'plans-export' %}" />
 		</span>
 		<span class="right-action">
 			{% paginate %}
@@ -41,10 +41,10 @@
 				<td><input type="checkbox" name="plan" value="{{ test_plan.pk }}" title="Select/Unselect"></td>
 				<td class="{% if not test_plan.is_active %}underline{% endif %}"><a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}</a></td>
 				<td class="{% if not test_plan.is_active %}underline{% endif %}"><a href="{{ test_plan.get_absolute_url }}" title="Go to {{ test_plan.name }}">{{ test_plan }} </a></td>
-				<td><a href="{% url "tcms.profiles.views.profile" test_plan.author.username %}">{{ test_plan.author }}</a></td>
+				<td><a href="{% url "tcms-profile" test_plan.author.username %}">{{ test_plan.author }}</a></td>
 				<td>
 					{% if test_plan.owner %}
-					<a href="{% url "tcms.profiles.views.profile" test_plan.owner.username %}">{{ test_plan.owner }}</a>
+					<a href="{% url "tcms-profile" test_plan.owner.username %}">{{ test_plan.owner }}</a>
 					{% else %}
 					No owner
 					{% endif %}
@@ -56,7 +56,7 @@
 				<td><a href="{{ test_plan.get_absolute_url }}#testruns" title="{{ test_plan.num_runs }} test runs">{{ test_plan.num_runs }}</a></td>
 				<td>
 					{% if perms.testplans.change_testplan %}
-					<a class="editlink" href="{% url "tcms.testplans.views.edit" test_plan.plan_id %}">Edit</a>
+					<a class="editlink" href="{% url "plan-edit" test_plan.plan_id %}">Edit</a>
 					{% endif %}
 				</td>
 			</tr>

--- a/tcms/templates/plan/common/plans_filtered.html
+++ b/tcms/templates/plan/common/plans_filtered.html
@@ -3,13 +3,13 @@
 		{#<span class="tit">{{ test_plans.count }} Plans</span>#}
 		<span>
 			{% if perms.testplans.add_testplan %}
-			<input type="button" title="Create new test plan" value="New Test Plan" class="js-new-plan" data-param="{% url 'tcms.testplans.views.new' %}" />
-			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plan" data-param="{% url 'tcms.testplans.views.clone' %}" />
+			<input type="button" title="Create new test plan" value="New Test Plan" class="js-new-plan" data-param="{% url 'plans-new' %}" />
+			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plan" data-param="{% url 'plans-clone' %}" />
 			{% endif %}
 			<input type="button" id="plan_list_printable"
                    disabled="disabled" value="Printable copy"
-                   title="Create the printable copy for selected plans." data-param="{% url 'tcms.testplans.views.printable' %}" />
-			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-cases" data-param="{% url 'tcms.testplans.views.export' %}" />
+                   title="Create the printable copy for selected plans." data-param="{% url 'plans-printable' %}" />
+			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-cases" data-param="{% url 'plans-export' %}" />
 		</span>
 	</div>
 	<table id="testplans_table" class="list border-bottom" cellpadding="0" cellspacing="0" border="0" style="table-layout:fixed;">

--- a/tcms/templates/plan/edit.html
+++ b/tcms/templates/plan/edit.html
@@ -36,7 +36,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Edit.on_load);
 
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan }}</a>
 		>> Edit

--- a/tcms/templates/plan/edit.html
+++ b/tcms/templates/plan/edit.html
@@ -37,19 +37,19 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Edit.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan }}</a>
 		>> Edit
 	</div>
 	<input id="id_plan_id" type="hidden" name="plan_id" value="{{ test_plan.plan_id }}">
 	<div class="control">
 		<span class="right-bar">
-			<a href="{% url "tcms.testplans.views.text_history" test_plan.plan_id %}" class="historylink">
+			<a href="{% url "plan-text_history" test_plan.plan_id %}" class="historylink">
 				Edit History
 			</a>
 		</span>
 	</div>
-	<form action="{% url "tcms.testplans.views.edit" test_plan.plan_id %}" method="post" enctype="multipart/form-data">
+	<form action="{% url "plan-edit" test_plan.plan_id %}" method="post" enctype="multipart/form-data">
 		<div id="" class="Detailform border-1">
 			<table class="editor" cellspacing="0">
 				<tr>

--- a/tcms/templates/plan/get.html
+++ b/tcms/templates/plan/get.html
@@ -51,7 +51,7 @@ Nitrate.TestPlans.Instance = {
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> {{ test_plan.plan_id }}: {{ test_plan.name }}
 	</div>

--- a/tcms/templates/plan/get.html
+++ b/tcms/templates/plan/get.html
@@ -52,14 +52,14 @@ Nitrate.TestPlans.Instance = {
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> {{ test_plan.plan_id }}: {{ test_plan.name }}
 	</div>
 	<input id="id_plan_id" type="hidden" name="plan_id" value="{{ test_plan.plan_id }}">
 	<div class="control">
 		<span id="id_buttons" class="button">
-			<input id="btn_edit" type="button" value="Edit Plan " title="Edit test plan" data-param="{% url 'tcms.testplans.views.edit' test_plan.plan_id %}" {% if perms.testplans.change_testplan %}{% else%}disabled{% endif %}>
-			<input id="btn_clone" type="button" value="Clone Plan" title="Clone this plan to other product" data-params='["{% url "tcms.testplans.views.clone" %}", {{ test_plan.plan_id }}]' {% if perms.testplans.add_testplan %}{% else %}disabled{% endif %}>
+			<input id="btn_edit" type="button" value="Edit Plan " title="Edit test plan" data-param="{% url 'plan-edit' test_plan.plan_id %}" {% if perms.testplans.change_testplan %}{% else%}disabled{% endif %}>
+			<input id="btn_clone" type="button" value="Clone Plan" title="Clone this plan to other product" data-params='["{% url "plans-clone" %}", {{ test_plan.plan_id }}]' {% if perms.testplans.add_testplan %}{% else %}disabled{% endif %}>
 			{% if test_plan.is_active %}
 			<input id="btn_disable" type="button" value="Disable Plan " title="Disabled this plan" {% if not perms.testplans.change_testplan %}disabled="true"{% endif %}>
 			{% else %}
@@ -67,14 +67,14 @@ Nitrate.TestPlans.Instance = {
 			{% endif %}
 			<input id="btn_export" type="button" value="Export All Cases "
                    title="Export all cases to XML file"
-                   data-params='["{% url "tcms.testplans.views.export" %}", {{ test_plan.pk }}]'>
+                   data-params='["{% url "plans-export" %}", {{ test_plan.pk }}]'>
 			<input id="btn_print" type="button" value="Print Plan "
                    title="Print Plan"
-                   data-params='["{% url "tcms.testplans.views.printable" %}", {{ test_plan.pk }}]'>
+                   data-params='["{% url "plans-printable" %}", {{ test_plan.pk }}]'>
 			{% comment %}
 			<span class="right-action">
 				<img src="{{ STATIC_URL }}images/icon_printer.png" width="16px">
-				<a href="{% url "tcms.testplans.views.printable" %}?plan={{ test_plan.pk }}">Print Plan</a>
+				<a href="{% url "plans-printable" %}?plan={{ test_plan.pk }}">Print Plan</a>
 			</span>
             {% endcomment %}
 		</span>
@@ -86,19 +86,19 @@ Nitrate.TestPlans.Instance = {
 		<div class="leftlistinfo">
 			<div class="listinfo">
 				<div class="title grey">Author&nbsp;:</div>
-				<div id="display_author"  class="name " > <a href="{% url "tcms.profiles.views.profile" test_plan.author.username %}">{{ test_plan.author }}</a></div>
+				<div id="display_author"  class="name " > <a href="{% url "tcms-profile" test_plan.author.username %}">{{ test_plan.author }}</a></div>
 			</div>
 			{% comment %}
             <div class="listinfo">
 				<div class="title grey">Doc Author/Manager&nbsp;:</div>
-				<div id="display_author"  class="name" ><a href="{% url "tcms.profiles.views.profile" test_plan.latest_text.author.username|default:"unknown" %}">{{ test_plan.latest_text.author }}</a></div>
+				<div id="display_author"  class="name" ><a href="{% url "tcms-profile" test_plan.latest_text.author.username|default:"unknown" %}">{{ test_plan.latest_text.author }}</a></div>
 			</div>
             {% endcomment %}
 			<div class="listinfo">
 				<div class="title grey">Owner&nbsp;:</div>
 				<div id="display_author"  class="name" >
 				{% if test_plan.owner %}
-				<a href="{% url "tcms.profiles.views.profile" test_plan.owner.username|default:"unknown" %}">{{ test_plan.owner }}</a>
+				<a href="{% url "tcms-profile" test_plan.owner.username|default:"unknown" %}">{{ test_plan.owner }}</a>
 				{% else %}
 				{{ test_plan.owner }}
 				{% endif %}
@@ -106,7 +106,7 @@ Nitrate.TestPlans.Instance = {
 			</div>
 			<div class="listinfo">
 				<div class="title grey">Product&nbsp;:</div>
-				<div id="display_product"  class="name "><a href="{% url "tcms.testplans.views.all" %}?action=search&name__icontains=&author__email__startswith=&owner__username__startswith=&type=&tag__name__in=&case__default_tester__username__startswith=&is_active=on&product={{ test_plan.product_id }}&product_version=&env_group=&create_date__gte=&create_date__lte=" title="Search plans of {{ test_plan.product }} ">{{ test_plan.product }}</a></div>
+				<div id="display_product"  class="name "><a href="{% url "plans-all" %}?action=search&name__icontains=&author__email__startswith=&owner__username__startswith=&type=&tag__name__in=&case__default_tester__username__startswith=&is_active=on&product={{ test_plan.product_id }}&product_version=&env_group=&create_date__gte=&create_date__lte=" title="Search plans of {{ test_plan.product }} ">{{ test_plan.product }}</a></div>
 			</div>
 			<div class="listinfo">
 				<div class="title grey">Version&nbsp;:</div>
@@ -122,7 +122,7 @@ Nitrate.TestPlans.Instance = {
 				<div class="title grey">Environment Group&nbsp;:</div>
 				<div class="name">
 					{% for env_group in test_plan.env_group.all %}
-					<span class="blue strong"><a href="{% url "tcms.testplans.views.all" %}?action=search&name__icontains=&author__email__startswith=&owner__username__startswith=&type=&tag__name__in=&case__default_tester__username__startswith=&product=&product_version=&env_group={{ env_group.id }}&create_date__gte=&create_date__lte=" title="Search plans of use {{ env_group.name }} ">{{ env_group.name }}</a></span>
+					<span class="blue strong"><a href="{% url "plans-all" %}?action=search&name__icontains=&author__email__startswith=&owner__username__startswith=&type=&tag__name__in=&case__default_tester__username__startswith=&product=&product_version=&env_group={{ env_group.id }}&create_date__gte=&create_date__lte=" title="Search plans of use {{ env_group.name }} ">{{ env_group.name }}</a></span>
 					{% endfor %}
 				</div>
 				<div id="display_summary" >
@@ -223,7 +223,7 @@ Nitrate.TestPlans.Instance = {
 		<div class="submit-row">
 			<input type="button" value="x" class="js-close-zone" >
 		</div>
-		<form action="{% url "tcms.testplans.views.cases" test_plan.plan_id %}" method="POST" enctype="multipart/form-data">
+		<form action="{% url "plan-cases" test_plan.plan_id %}" method="POST" enctype="multipart/form-data">
 			<div  class="right-bar" >
 				<label class="errors" id="import-error">{{ xml_form.xml_file.errors }}</label>	
 				{{ xml_form.a }}

--- a/tcms/templates/plan/get_attachments.html
+++ b/tcms/templates/plan/get_attachments.html
@@ -1,7 +1,7 @@
 <div class="mixbar">
 	<span class="tit">Add attachment</span>
 	{% if perms.management.add_testattachment %}
-	<a href="{% url "tcms.testplans.views.attachment" test_plan.plan_id %}" class="addlink">add</a>
+	<a href="{% url "plan-attachment" test_plan.plan_id %}" class="addlink">add</a>
 	{% endif %}
 </div>
 <table class="list" cellspacing="0" cellspan="0" width="100%">
@@ -17,11 +17,11 @@
 	<tbody>
 		{% for attachment in test_plan.attachment.all %}
 		<tr id="{{ attachment.attachment_id }}" class="{% cycle 'odd' 'even' %}">
-			<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
+			<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">{{ attachment.file_name }}</a></td>
 			<td>{{ attachment.submitter }}</td>
 			<td>{{ attachment.create_date }}</td>
 			<td>{{ attachment.mime_type }}</td>
-			<td><a href="{% url "tcms.core.files.check_file" attachment.attachment_id %}">View</a> | <a class="js-del-attach" data-params="[{{attachment.attachment_id}}, {{test_plan.plan_id}}]" href="#">Delete</a></td>
+			<td><a href="{% url "mgmt-check_file" attachment.attachment_id %}">View</a> | <a class="js-del-attach" data-params="[{{attachment.attachment_id}}, {{test_plan.plan_id}}]" href="#">Delete</a></td>
 		</tr>
 		{% empty %}
 		<tr><td colspan="5" align="center"><span class="grey">No attachments</span></td></tr>

--- a/tcms/templates/plan/get_cases.html
+++ b/tcms/templates/plan/get_cases.html
@@ -1,6 +1,6 @@
 {% load ifin %}
 {% load testcase_tags %}
-<form id="js-cases-nav-form" action="{% url "tcms.testcases.views.all" %}" method="get">
+<form id="js-cases-nav-form" action="{% url "testcases-all" %}" method="get">
 	<input type="hidden" name="type" value="case" />
 	<input type="hidden" name="case_sort_by" value="{{ REQUEST_CONTENTS.case_sort_by }}" />
 	<input type="hidden" name="plan" value="{{ REQUEST_CONTENTS.from_plan }}" />
@@ -13,24 +13,24 @@
 			<ul>
 				<li>
 					{% if perms.testcases.add_testcase %}
-					<span id="js-case-menu" class='sprites toolbar_case icon_plan' data-params='["{% url "tcms.testcases.views.new" %}", {{ test_plan.plan_id }}]'>Case</span>
+					<span id="js-case-menu" class='sprites toolbar_case icon_plan' data-params='["{% url "testcases-new" %}", {{ test_plan.plan_id }}]'>Case</span>
 					{% else %}
 					<span class='sprites toolbar_case icon_plan'>Case</span>
 					{% endif %}
 					<ul>
 						{% if perms.testcases.add_testcase %}
-						<li><input id="js-new-case" class="add_new icon_plan" type="button" value="Write new case" data-params='["{% url "tcms.testcases.views.new" %}", {{ test_plan.plan_id }}]'/></li>
+						<li><input id="js-new-case" class="add_new icon_plan" type="button" value="Write new case" data-params='["{% url "testcases-new" %}", {{ test_plan.plan_id }}]'/></li>
 						<li><input id="js-import-case" type="button" class="import icon_plan" value="Import cases from XML" /></li>
-						<li><input id="js-add-case-to-plan" type="button" class="search icon_plan" value="Add cases from other plans" data-param="{% url "tcms.testplans.views.cases" test_plan.plan_id %}" /></li>
+						<li><input id="js-add-case-to-plan" type="button" class="search icon_plan" value="Add cases from other plans" data-param="{% url "plan-cases" test_plan.plan_id %}" /></li>
 						{% else %}
 						<li><input type="button" class="add_new icon_plan" disabled="true" value="Write new case"/></li>
 						<li><input type="button" class="import icon_plan" disabled="true" value="Import cases from XML"	/></li>
 						<li><input type="button" class="search icon_plan" disabled="true" value="Add cases from other plans" /></li>
 						{% endif %}
-						<li><input type="button" id="js-export-case" class="export icon_plan" title="Export selected cases into XML file" value="Export" data-param="{% url "tcms.testcases.views.export" %}" /></li>
-						<li><input type="button" id="js-print-case" class="print_view icon_plan" value="Print"  title="print view of selected cases" data-param="{% url "tcms.testcases.views.printable" %}" /></li>
+						<li><input type="button" id="js-export-case" class="export icon_plan" title="Export selected cases into XML file" value="Export" data-param="{% url "testcases-export" %}" /></li>
+						<li><input type="button" id="js-print-case" class="print_view icon_plan" value="Print"  title="print view of selected cases" data-param="{% url "testcases-printable" %}" /></li>
 						{% if perms.testcases.add_testcase %}
-						<li><input type="button" id="js-clone-case" class="clone icon_plan" value="Clone" title="Clone selected cases to another test plan" data-param="{% url "tcms.testcases.views.clone" %}" /></li>
+						<li><input type="button" id="js-clone-case" class="clone icon_plan" value="Clone" title="Clone selected cases to another test plan" data-param="{% url "testcases-clone" %}" /></li>
 						{% else %}
 						<li><input type="button" class="clone icon_plan" value="Clone" title="Clone selected cases to another test plan" disabled="true"/></li>
 						{% endif %}

--- a/tcms/templates/plan/get_docs.html
+++ b/tcms/templates/plan/get_docs.html
@@ -1,4 +1,4 @@
-<a href="{% url "tcms.testplans.views.text_history" test_plan.plan_id %}" class="historylink right-action">
+<a href="{% url "plan-text_history" test_plan.plan_id %}" class="historylink right-action">
 	View edit history
 </a>
 <div class="listinfo_doc_content">

--- a/tcms/templates/plan/get_review_cases.html
+++ b/tcms/templates/plan/get_review_cases.html
@@ -1,6 +1,6 @@
 {% load comments %}
 {% load testcase_tags %}
-<form id="js-review-cases-nav-form" action="{% url "tcms.testcases.views.all" %}" method="get">
+<form id="js-review-cases-nav-form" action="{% url "testcases-all" %}" method="get">
 	<input type="hidden" name="template_type" value="review_case" />
 	<input type="hidden" name="case_sort_by" value="{{ REQUEST_CONTENTS.case_sort_by }}" />
 	<input type="hidden" name="plan" value="{{ REQUEST_CONTENTS.from_plan }}" />
@@ -13,24 +13,24 @@
 			<ul>
 				<li>
 					{% if perms.testcases.add_testcase %}
-					<span id="js-review-case-menu" class='sprites toolbar_case icon_plan' data-params='["{% url "tcms.testcases.views.new" %}", {{ test_plan.plan_id }}]'>Case</span>
+					<span id="js-review-case-menu" class='sprites toolbar_case icon_plan' data-params='["{% url "testcases-new" %}", {{ test_plan.plan_id }}]'>Case</span>
 					{% else %}
 					<span class='sprites toolbar_case icon_plan'>Case</span>
 					{% endif %}
 					<ul>
 						{% if perms.testcases.add_testcase %}
-						<li><input id="js-review-new-case" class="add_new icon_plan" type="button" value="Write new case" data-params='["{% url "tcms.testcases.views.new" %}", {{ test_plan.plan_id }}]'/></li>
+						<li><input id="js-review-new-case" class="add_new icon_plan" type="button" value="Write new case" data-params='["{% url "testcases-new" %}", {{ test_plan.plan_id }}]'/></li>
 						<li><input id="js-review-import-case" type="button" class="import icon_plan" value="Import cases from XML" /></li>
-						<li><input id="js-review-add-case-to-plan" type="button" class="search icon_plan" value="Add cases from other plans" data-param="{% url "tcms.testplans.views.cases" test_plan.plan_id %}" /></li>
+						<li><input id="js-review-add-case-to-plan" type="button" class="search icon_plan" value="Add cases from other plans" data-param="{% url "plan-cases" test_plan.plan_id %}" /></li>
 						{% else %}
 						<li><input class="add_new icon_plan" type="button" disabled="true" value="Write new case"/></li>
 						<li><input type="button" class="import icon_plan" disabled="true" value="Import cases from XML"	/></li>
 						<li><input type="button" class="search icon_plan" disabled="true" value="Add cases from other plans"	 /></li>
 						{% endif %}
-						<li><input type="button" id="js-review-export-case" class="export icon_plan" title="Export selected cases into XML file" value="Export" data-param="{% url "tcms.testcases.views.export" %}" /></li>
-						<li><input type="button" id="js-review-print-case" class="print_view icon_plan" value="Print"  title="print view of selected cases" data-param="{% url "tcms.testcases.views.printable" %}" /></li>
+						<li><input type="button" id="js-review-export-case" class="export icon_plan" title="Export selected cases into XML file" value="Export" data-param="{% url "testcases-export" %}" /></li>
+						<li><input type="button" id="js-review-print-case" class="print_view icon_plan" value="Print"  title="print view of selected cases" data-param="{% url "testcases-printable" %}" /></li>
 						{% if perms.testcases.add_testcase %}
-						<li><input type="button" id="js-review-clone-case" class="clone icon_plan" value="Clone" title="Clone selected cases to another test plan" data-param="{% url "tcms.testcases.views.clone" %}" /></li>
+						<li><input type="button" id="js-review-clone-case" class="clone icon_plan" value="Clone" title="Clone selected cases to another test plan" data-param="{% url "testcases-clone" %}" /></li>
 						{% else %}
 						<li><input type="button" class="clone icon_plan" value="Clone" title="Clone selected cases to another test plan" disabled="true"/></li>
 						{% endif %}

--- a/tcms/templates/plan/get_runs.html
+++ b/tcms/templates/plan/get_runs.html
@@ -54,7 +54,7 @@
 	</form>
 </div>
 
-<form id='id_form_run' action="{% url "tcms.testruns.views.clone" %}" method="get">
+<form id='id_form_run' action="{% url "testruns-clone" %}" method="get">
 	<input type="hidden" name="from_plan" value="{{ test_plan.pk }}" />
 	<input type="hidden" name="product" value="{{ test_plan.product.pk }}" />
 	<input type="hidden" name="product_version" value="{{ test_plan.product_version_id }}" />

--- a/tcms/templates/plan/history.html
+++ b/tcms/templates/plan/history.html
@@ -19,7 +19,7 @@
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> <a href="{{ testplan.get_absolute_url }}">{{ testplan.plan_id }}: {{ testplan.name }}</a>
 		>> Edit History
 	</div>
@@ -34,7 +34,7 @@
 		</tr>
 		{% for plan_text in test_plan_texts %}
 		<tr class="{% cycle 'even' 'odd' %}">
-			<td><a href="{% url "tcms.testplans.views.text_history" testplan.plan_id %}?plan_text_version={{ plan_text.plan_text_version }}">{{ plan_text.plan_text_version }}</a></td>
+			<td><a href="{% url "plan-text_history" testplan.plan_id %}?plan_text_version={{ plan_text.plan_text_version }}">{{ plan_text.plan_text_version }}</a></td>
 			<td>{{ plan_text.create_date }}</td>
 			<td>{{ plan_text.author.email }}</td>
 			<td>

--- a/tcms/templates/plan/history.html
+++ b/tcms/templates/plan/history.html
@@ -18,7 +18,7 @@
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> <a href="{{ testplan.get_absolute_url }}">{{ testplan.plan_id }}: {{ testplan.name }}</a>
 		>> Edit History

--- a/tcms/templates/plan/new.html
+++ b/tcms/templates/plan/new.html
@@ -22,10 +22,10 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Create.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> New Test Plan
 	</div>
-	<form method="post" action="{% url "tcms.testplans.views.new" %}" enctype="multipart/form-data">
+	<form method="post" action="{% url "plans-new" %}" enctype="multipart/form-data">
 		<h2>Create New Test Plan</h2>
 		<div class="Detailform border-1" >
 			<table class="editor" cellspan="0" cellspacing="0">

--- a/tcms/templates/plan/new.html
+++ b/tcms/templates/plan/new.html
@@ -21,7 +21,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.Create.on_load);
 
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> New Test Plan
 	</div>

--- a/tcms/templates/plan/plan_runs_part.html
+++ b/tcms/templates/plan/plan_runs_part.html
@@ -2,13 +2,13 @@
 <tr class="{% cycle 'odd' 'even' %}" id="run_{{test_run.run_id}}">
 	<td><input type="checkbox" class="run_selector" name="run" value="{{ test_run.pk }}"/></td>
 	<td	 valign="top">
-		<a href="{% url "tcms.testruns.views.get" test_run.run_id %}?from_plan={{ test_plan.plan_id }}">{{ test_run.run_id }}</a>
+		<a href="{% url "testruns-get" test_run.run_id %}?from_plan={{ test_plan.plan_id }}">{{ test_run.run_id }}</a>
 	</td>
 	<td valign="top" class="subject">
-		<a href="{% url "tcms.testruns.views.get" test_run.run_id %}?from_plan={{ test_plan.plan_id }}">{{ test_run.summary }}</a>
+		<a href="{% url "testruns-get" test_run.run_id %}?from_plan={{ test_plan.plan_id }}">{{ test_run.summary }}</a>
 	</td>
-	<td valign="top"><a href="{% url "tcms.profiles.views.profile" test_run.manager.username %}">{{ test_run.manager }}</a></td>
-	<td valign="top">{% if test_run.default_tester_id %}<a href="{% url "tcms.profiles.views.profile" test_run.default_tester.username %}">{{ test_run.default_tester }}</a>{% else%} None{% endif %}</td>
+	<td valign="top"><a href="{% url "tcms-profile" test_run.manager.username %}">{{ test_run.manager }}</a></td>
+	<td valign="top">{% if test_run.default_tester_id %}<a href="{% url "tcms-profile" test_run.default_tester.username %}">{{ test_run.default_tester }}</a>{% else%} None{% endif %}</td>
 	<td valign="top">{{ test_run.start_date }}</td>
 	<td valign="top">{{ test_run.build }}</td>
 	<td valign="top">{% if test_run.stop_date %}Finished{% else %}Running{% endif %}</td>

--- a/tcms/templates/plan/report.html
+++ b/tcms/templates/plan/report.html
@@ -14,7 +14,7 @@
 
 <div id="content">
     <div class="sprites crumble">
-        <a href="{% url "tcms.core.views.index" %}">Home</a>
+        <a href="{% url "core-views-index" %}">Home</a>
         >> <a href="{% url "tcms.testplans.views.all" %}">Planning</a> 
         >> <a href="{{ test_plan.get_absolute_url }}">{{ testplan.plan_id }}: {{ testplan.title }}</a>
         >> Report

--- a/tcms/templates/plan/report.html
+++ b/tcms/templates/plan/report.html
@@ -15,7 +15,7 @@
 <div id="content">
     <div class="sprites crumble">
         <a href="{% url "core-views-index" %}">Home</a>
-        >> <a href="{% url "tcms.testplans.views.all" %}">Planning</a> 
+        >> <a href="{% url "plans-all" %}">Planning</a> 
         >> <a href="{{ test_plan.get_absolute_url }}">{{ testplan.plan_id }}: {{ testplan.title }}</a>
         >> Report
     </div>

--- a/tcms/templates/plan/search_case.html
+++ b/tcms/templates/plan/search_case.html
@@ -23,7 +23,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 		<input id="value_product_id" type="hidden" mame="product_id" value="{{ test_plan.product_id }}">
 	</div>
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		>> Add cases from other plans

--- a/tcms/templates/plan/search_case.html
+++ b/tcms/templates/plan/search_case.html
@@ -24,7 +24,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 	</div>
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		>> Add cases from other plans
 	</div>
@@ -33,7 +33,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 	<div class="Detailform border-1">
 		<div class="Detailform-variety_0">
 			<div class="grey tit">Search cases to add into this test plan.</div>
-			<form action="{% url "tcms.testplans.views.cases" test_plan.plan_id %}" method="post">
+			<form action="{% url "plan-cases" test_plan.plan_id %}" method="post">
 				<fieldset class="no-border">
 				<input type="hidden" name="a" value="link_cases" />
 				<input type="hidden" name="action" value="search" />
@@ -72,7 +72,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 			</form>
 			</fieldset>
 		</div>
-		<form id="id_form_cases" action="{% url "tcms.testplans.views.cases" test_plan.plan_id %}" method="post">
+		<form id="id_form_cases" action="{% url "plan-cases" test_plan.plan_id %}" method="post">
 			<input type="hidden" name="a" value="link_cases">
 			<input type="hidden" name="action" value="add_to_plan">
 			{% if test_cases %}
@@ -98,7 +98,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 					{% for test_case in test_cases %}
 					<tr class="{% cycle 'odd' 'even' %}">
 						<td align="left"><input id="id_checkbox_case_{{ forloop.counter }}" type="checkbox" name="case" value="{{ test_case.case_id }}"></td>
-						<td><a href="{% url "tcms.testcases.views.get" test_case.case_id %}">{{ test_case.case_id }}</a></td>
+						<td><a href="{% url "testcases-get" test_case.case_id %}">{{ test_case.case_id }}</a></td>
 						<td valign="top" >{{ test_case.summary }}</td>
 						<td valign="top" >{{ test_case.author.email }}</td>
 						<td valign="top" >{{ test_case.default_tester.email }}</td>

--- a/tcms/templates/profile/bookmarks.html
+++ b/tcms/templates/profile/bookmarks.html
@@ -20,14 +20,14 @@ Nitrate.Utils.after_page_load(Nitrate.Profiles.Bookmarks.on_load);
 <div id="content">
 	<div class="sprites crumble profile_tab">
 		<ul>
-			<li><a href="{% url "tcms.profiles.views.profile" user.username %}">Basic Information</a></li>
+			<li><a href="{% url "tcms-profile" user.username %}">Basic Information</a></li>
 			{% ifequal user_profile.user user %}
-			<li  class="profile_tab_active"><a href="{% url "tcms.profiles.views.bookmark" user.username %}">Bookmarks</a></li>
-			<li><a href="{% url "tcms.profiles.views.recent" user.username %}">Recent</a></li>
+			<li  class="profile_tab_active"><a href="{% url "tcms-bookmark" user.username %}">Bookmarks</a></li>
+			<li><a href="{% url "tcms-recent" user.username %}">Recent</a></li>
 			{% endifequal %}
 		</ul>
 	</div>
-	<form id="id_form_bookmark" action="{% url "tcms.profiles.views.bookmark" user.username %}" method="post">
+	<form id="id_form_bookmark" action="{% url "tcms-bookmark" user.username %}" method="post">
 		<div class="table_watchlist_toolbar">
 			<span>
 				{# <a href="#" class="sprites node_add">Add</a> #}

--- a/tcms/templates/profile/info.html
+++ b/tcms/templates/profile/info.html
@@ -14,10 +14,10 @@
 <div id="content">
 	<div class="sprites crumble profile_tab">
 		<ul>
-			<li class="profile_tab_active"><a href="{% url "tcms.profiles.views.profile" user.username %}">Basic Information</a></li>
+			<li class="profile_tab_active"><a href="{% url "tcms-profile" user.username %}">Basic Information</a></li>
 			{% ifequal user_profile.user user %}
-			<li><a href="{% url "tcms.profiles.views.bookmark" user.username %}">Bookmarks</a></li>
-			<li><a href="{% url "tcms.profiles.views.recent" user.username %}">Recent</a></li>
+			<li><a href="{% url "tcms-bookmark" user.username %}">Bookmarks</a></li>
+			<li><a href="{% url "tcms-recent" user.username %}">Recent</a></li>
 			{% endifequal %}
 		</ul>
 	</div>

--- a/tcms/templates/profile/recent.html
+++ b/tcms/templates/profile/recent.html
@@ -15,10 +15,10 @@
 <div id="content" >
 	<div class="sprites crumble profile_tab">
 		<ul>
-			<li><a href="{% url "tcms.profiles.views.profile" user.username %}">Basic Information</a></li>
+			<li><a href="{% url "tcms-profile" user.username %}">Basic Information</a></li>
 			{% ifequal user_profile.user user %}
-			<li><a href="{% url "tcms.profiles.views.bookmark" user.username %}">Bookmarks</a></li>
-			<li class="profile_tab_active"><a href="{% url "tcms.profiles.views.recent" user.username %}">Recent</a></li>
+			<li><a href="{% url "tcms-bookmark" user.username %}">Bookmarks</a></li>
+			<li class="profile_tab_active"><a href="{% url "tcms-recent" user.username %}">Recent</a></li>
 			{% endifequal %}
 		</ul>
 	</div>
@@ -41,7 +41,7 @@
 						
 					</td>
 					<td colspan="3">
-						<a	class="link" href="{% url "tcms.testruns.views.get" test_run.run_id %}">
+						<a	class="link" href="{% url "testruns-get" test_run.run_id %}">
 							{{ test_run.summary }}
 						</a>
 						<div class="grey" style="margin-top:5px">Start at {{ test_run.start_date }}</div>
@@ -56,7 +56,7 @@
                         {{ test_runs_count }} test run(s) related to you need to be run, here {% ifequal test_runs_count 1 %}is{% else %}are{% endifequal %} the latest {{ last_15_test_runs|length }}.</div>
 							<div class="sprites tablefooterleft"></div>
                             
-                            <a href="{% url "tcms.testruns.views.all" %}?people={{ user.email|iriencode }}&status=running" class="seeall"> SEE ALL</a>
+                            <a href="{% url "testruns-all" %}?people={{ user.email|iriencode }}&status=running" class="seeall"> SEE ALL</a>
 							<div class="sprites tablefooterright"></div>
 						</div>
 						{% else %}
@@ -95,14 +95,14 @@
 						<div class="sprites tablefooter"> 
                             <div class="left_float">You manage {{ test_plans_count }} test plan(s), {{ test_plans_disable_count }} test plan(s) disabled, here {% ifequal test_plans_count 1 %}is{% else %}are{% endifequal %} the latest {{ last_15_test_plans|length }}.</div>
 							<div class="sprites tablefooterleft"></div>
-                            <a class="seeall" href="{% url "tcms.testplans.views.all" %}?author__email__startswith={{ user.email|iriencode }}">SEE ALL</a>
+                            <a class="seeall" href="{% url "plans-all" %}?author__email__startswith={{ user.email|iriencode }}">SEE ALL</a>
 							<div class="sprites tablefooterright"></div>
 						</div>
 						{% else %}
 						<div class="sprites tablefooter">
 							<div class="left_float">No plan belong to you</div>
                             <div class="sprites tablefooterleft"></div>
-							<div class="sprites tablefooterright"></div><a class="create" href="{% url "tcms.testplans.views.new" %}">Create</a>
+							<div class="sprites tablefooterright"></div><a class="create" href="{% url "plans-new" %}">Create</a>
 						</div>
 						{% endif %}
 					</th>

--- a/tcms/templates/registration/login.html
+++ b/tcms/templates/registration/login.html
@@ -12,7 +12,7 @@
 	<div id="index" >
 		<br clear="all">
 		<div class="login radius">
-			<form id="id_login_form" action="{% url "django.contrib.auth.views.login" %}" method="POST">
+			<form id="id_login_form" action="{% url "tcms-login" %}" method="POST">
 				{% csrf_token %}
 				{% if SETTINGS.MOTD_LOGIN %}
 				<div class="cc">{{ SETTINGS.MOTD_LOGIN|safe}}</div>
@@ -25,7 +25,7 @@
 					</tr>
                     <tr>
                     	<td></td>
-						<td ><a href="{% url "django.contrib.auth.views.password_reset" %}">Forget the password</a></td>
+						<td ><a href="{% url "tcms-password_reset" %}">Forget the password</a></td>
 					</tr>
 					<tr>
                     	<td>&nbsp;</td>

--- a/tcms/templates/registration/password_reset_form.html
+++ b/tcms/templates/registration/password_reset_form.html
@@ -13,7 +13,7 @@
 	<div id="index" >
 		<br clear="all">
 		<div class="login radius">
-			<form id="id_register_form" action="{% url "django.contrib.auth.views.password_reset" %}" method="POST">
+			<form id="id_register_form" action="{% url "tcms-password_reset" %}" method="POST">
 				{% csrf_token %}
 				<table border="0" cellpadding="10" cellspacing="10" class="login_table">
 					<tr>

--- a/tcms/templates/registration/registration_form.html
+++ b/tcms/templates/registration/registration_form.html
@@ -12,7 +12,7 @@
 	<div id="index" >
 		<br clear="all">
 		<div class="login radius">
-			<form id="id_register_form" action="{% url "tcms.core.contrib.auth.views.register" %}" method="POST">
+			<form id="id_register_form" action="{% url "tcms-register" %}" method="POST">
 				{% if SETTINGS.MOTD_LOGIN %}
 				<div class="cc">{{ SETTINGS.MOTD_LOGIN|safe}}</div>
 				{% endif %}

--- a/tcms/templates/report/build.html
+++ b/tcms/templates/report/build.html
@@ -20,7 +20,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.Builds.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt;<a href="/report">Reporting</a>
 		&gt;&gt;{{ product }}
 	</div>

--- a/tcms/templates/report/caseruns.html
+++ b/tcms/templates/report/caseruns.html
@@ -12,7 +12,7 @@
 
 {% block contents %}
 <div id="content">
-	<div class="sprites crumble"><a href="{% url "tcms.core.views.index" %}">Home</a> &gt;&gt; <a href="{% url "testing-report" %}">Testing Report</a></div>
+	<div class="sprites crumble"><a href="{% url "core-views-index" %}">Home</a> &gt;&gt; <a href="{% url "testing-report" %}">Testing Report</a></div>
 	{% if form_errors %}
 	<div>{{ form_errors }}</div>
 	{% else %}

--- a/tcms/templates/report/caseruns_table.html
+++ b/tcms/templates/report/caseruns_table.html
@@ -19,22 +19,22 @@
 		{% for test_case_run, status_name, priority_value, tester, assignee in test_case_runs %}
 		<tr class="{% cycle 'odd' 'even' %} {% ifequal assignee.0 user.pk %} mine {%endifequal%}">
 			<td>
-				<a target="_blank" href="{% url "tcms.testruns.views.get" test_case_run.run.pk %}#caserun_{{ test_case_run.pk }}">#{{ test_case_run.pk }}</a>
+				<a target="_blank" href="{% url "testruns-get" test_case_run.run.pk %}#caserun_{{ test_case_run.pk }}">#{{ test_case_run.pk }}</a>
 			</td>
 			<td "{{ test_case_run.case_id }}" class="case_title expandable">
-				<a href="{% url 'tcms.testcases.views.get' test_case_run.case_id %}?from_plan={{ test_case_run.run.plan_id }}">{{ test_case_run.case_id }}</a>
+				<a href="{% url 'testcases-get' test_case_run.case_id %}?from_plan={{ test_case_run.run.plan_id }}">{{ test_case_run.case_id }}</a>
 			</td>
 			<td>
-				<a id="link_{{ forloop.counter }}" target="_blank" href="{% url 'tcms.testruns.views.get' test_case_run.run.pk %}?#caserun_{{ test_case_run.pk }}" title="Expand test case">{{ test_case_run.case.summary }}</a>
+				<a id="link_{{ forloop.counter }}" target="_blank" href="{% url 'testruns-get' test_case_run.run.pk %}?#caserun_{{ test_case_run.pk }}" title="Expand test case">{{ test_case_run.case.summary }}</a>
 			</td>
 			<td>
 				{% if tester.1 %}
-				<a target="_blank" href="{% url "tcms.profiles.views.profile" tester.1 %}" class="link_tested_by">{{ tester.1 }}</a>
+				<a target="_blank" href="{% url "tcms-profile" tester.1 %}" class="link_tested_by">{{ tester.1 }}</a>
 				{% else %}None{% endif %}
 			</td>
 			<td>
 				{% if assignee.1 %}
-				<a href="{% url "tcms.profiles.views.profile" assignee.1 %}" class="link_assignee">{{ assignee.1 }}</a>
+				<a href="{% url "tcms-profile" assignee.1 %}" class="link_assignee">{{ assignee.1 }}</a>
 				{% else %}None{% endif %}
 			</td>
 			<td>{{ test_case_run.case.get_is_automated_status }}</td>

--- a/tcms/templates/report/component.html
+++ b/tcms/templates/report/component.html
@@ -15,7 +15,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.List.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt;<a href="/report">Reporting</a>
 		&gt;&gt;{{ product }}
 	</div>

--- a/tcms/templates/report/custom_details.html
+++ b/tcms/templates/report/custom_details.html
@@ -18,7 +18,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.CustomDetails.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt; <a href="{% url "report-custom" %}">Custom</a>
 		&gt;&gt; {% for build in builds %}{{ build.build__name }}{% endfor %}
 	</div>

--- a/tcms/templates/report/custom_details_case_runs.html
+++ b/tcms/templates/report/custom_details_case_runs.html
@@ -12,7 +12,7 @@
 	{% for test_case_run, bugs, comments in case_runs %}
 	<tr>
 		<td valign="top"><a href="{{ test_case_run.case.get_url_path }}">{{ test_case_run.case.pk }}</a></td>
-		<td valign="top"><a href="{% url 'tcms.testruns.views.get' test_case_run.run_id %}#caserun_{{ test_case_run.pk }}">{{ test_case_run.pk }}</a></td>
+		<td valign="top"><a href="{% url 'testruns-get' test_case_run.run_id %}#caserun_{{ test_case_run.pk }}">{{ test_case_run.pk }}</a></td>
 		<td valign="top">{{ test_case_run.case.summary }}</td>
 		<td valign="top">{{ test_case_run.case.category }}</td>
 		<td valign="top">{{ test_case_run.tested_by }}</td>

--- a/tcms/templates/report/custom_search.html
+++ b/tcms/templates/report/custom_search.html
@@ -20,7 +20,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.CustomSearch.on_load);
 
 {% block contents %}
 <div id="content">
-	<div class="sprites crumble"><a href="{% url "tcms.core.views.index" %}">Home</a> &gt;&gt; Custom Reporting</div>
+	<div class="sprites crumble"><a href="{% url "core-views-index" %}">Home</a> &gt;&gt; Custom Reporting</div>
 	<div class="itemSearch">
 		<h2>Report Options</h2>
 		<form id="id_form_search" action="{% url "report-custom" %}">

--- a/tcms/templates/report/custom_search.html
+++ b/tcms/templates/report/custom_search.html
@@ -57,7 +57,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.CustomSearch.on_load);
 				<td valign="top">{{ build.plans_count|default_if_none:0 }}</td>
 				<td valign="top">
 				{% if build.runs_count %}
-					<a href="{% url "tcms.testruns.views.all" %}?product={{ build.product.pk }}&build={{ build.pk }}&product_version={{ REQUEST_CONTENTS.build_run__product_version }}">{{ build.runs_count }}</a>
+					<a href="{% url "testruns-all" %}?product={{ build.product.pk }}&build={{ build.pk }}&product_version={{ REQUEST_CONTENTS.build_run__product_version }}">{{ build.runs_count }}</a>
 				{% else %}{{ build.runs_count|default_if_none:0 }}{% endif %}
 				</td>
 				<td valign="top">{{ build.case_runs_count|default_if_none:0 }}</td>

--- a/tcms/templates/report/list.html
+++ b/tcms/templates/report/list.html
@@ -16,7 +16,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.List.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> Reporting
 	</div>
 	<h1>Product</h1>

--- a/tcms/templates/report/overview.html
+++ b/tcms/templates/report/overview.html
@@ -13,7 +13,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.List.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt;<a href="/report">Reporting</a>
 		&gt;&gt;{{ product }}
 	</div>

--- a/tcms/templates/report/version.html
+++ b/tcms/templates/report/version.html
@@ -18,7 +18,7 @@ Nitrate.Utils.after_page_load(Nitrate.Report.List.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt;<a href="/report">Reporting</a>
 		&gt;&gt;{{ product }}
 	</div>

--- a/tcms/templates/run/all.html
+++ b/tcms/templates/run/all.html
@@ -23,12 +23,12 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.List.on_load);
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
 		{% if query_result %}
-		>> <a href="{% url "tcms.testruns.views.all" %}">Test Runs</a> >> Search result
+		>> <a href="{% url "testruns-all" %}">Test Runs</a> >> Search result
 		{% else %}
 		>> Test Runs
 		{% endif %}
 	</div>
-	<form action="{% url "tcms.testruns.views.all" %}" method="get">
+	<form action="{% url "testruns-all" %}" method="get">
 		<div id="itemSearch" class="itemSearch">
 			<input type="hidden" name="action" value="search" />
 			<div>
@@ -49,8 +49,8 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.List.on_load);
 	{% if REQUEST_CONTENTS.items %}
 	<div id="contentTab" class="mixbar">
 		{# <span class="tit">{{ test_runs.count }} Test Runs</span> #}
-		<span class="tit"><a href="{% url "tcms.testruns.views.all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
-		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param='{% url "tcms.testruns.views.clone" %}' />
+		<span class="tit"><a href="{% url "testruns-all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
+		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param='{% url "testruns-clone" %}' />
 	</div>
 	{% include "run/common/run_filtered.html" %}
 	{% else %}

--- a/tcms/templates/run/all.html
+++ b/tcms/templates/run/all.html
@@ -21,7 +21,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.List.on_load);
 
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if query_result %}
 		>> <a href="{% url "tcms.testruns.views.all" %}">Test Runs</a> >> Search result
 		{% else %}

--- a/tcms/templates/run/assign_case.html
+++ b/tcms/templates/run/assign_case.html
@@ -19,7 +19,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.AssignCase.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">...</a>
 		&gt;&gt; <a href="{{ test_run.plan.get_absolute_url }}">...</a>
 		&gt;&gt; <a href="{% url "tcms.testruns.views.get" test_run.run_id %}">{{ test_run.run_id }}: {{ test_run.summary }}</a>

--- a/tcms/templates/run/assign_case.html
+++ b/tcms/templates/run/assign_case.html
@@ -20,12 +20,12 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.AssignCase.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">...</a>
+		&gt;&gt; <a href="{% url "plans-all" %}">...</a>
 		&gt;&gt; <a href="{{ test_run.plan.get_absolute_url }}">...</a>
-		&gt;&gt; <a href="{% url "tcms.testruns.views.get" test_run.run_id %}">{{ test_run.run_id }}: {{ test_run.summary }}</a>
+		&gt;&gt; <a href="{% url "testruns-get" test_run.run_id %}">{{ test_run.run_id }}: {{ test_run.summary }}</a>
 		&gt;&gt; Add test case
 	</div>
-	<h2 id="display_title"><a href="{% url "tcms.testruns.views.get" test_run.run_id %}">{{ test_run.summary }}</a></h2>
+	<h2 id="display_title"><a href="{% url "testruns-get" test_run.run_id %}">{{ test_run.summary }}</a></h2>
 	<table class="runsDetail" border="0" width="66%" cellspacing="0" cellpadding="0">
 		<tr class="cell">
 			<td class="lab">Build</td>
@@ -97,7 +97,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.AssignCase.on_load);
 							</a>
 						</td>
 						<td>
-							<a href="{% url "tcms.testcases.views.get" test_case.case %}">{{ test_case.case }}</a>
+							<a href="{% url "testcases-get" test_case.case %}">{{ test_case.case }}</a>
 						</td>
 						<td class="js-case-summary" data-param="{{ forloop.counter }}" >
 							<a id="link_{{ forloop.counter }}" class="blind_title_link" href="javascript:void(0);">

--- a/tcms/templates/run/clone.html
+++ b/tcms/templates/run/clone.html
@@ -30,7 +30,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 		<input id="value_sub_module" type="hidden" name="sub_module" value="{{ sub_module }}" />
 	</div>
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">...</a>
 		>> <a href="{{ test_run.plan.get_absolute_url }}">...</a>
 		>> <a href="{% url "tcms.testruns.views.get" test_run.run_id %}">{{ test_run.summary }}</a>

--- a/tcms/templates/run/clone.html
+++ b/tcms/templates/run/clone.html
@@ -31,9 +31,9 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 	</div>
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">...</a>
+		>> <a href="{% url "plans-all" %}">...</a>
 		>> <a href="{{ test_run.plan.get_absolute_url }}">...</a>
-		>> <a href="{% url "tcms.testruns.views.get" test_run.run_id %}">{{ test_run.summary }}</a>
+		>> <a href="{% url "testruns-get" test_run.run_id %}">{{ test_run.summary }}</a>
 		>> Clone
 	</div>
 	<h2>Clone Test Run - {{ test_run.summary }}</h2>
@@ -169,7 +169,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 							</a>
 						</td>
 						<td>
-							<a href="{% url "tcms.testcases.views.get" case_run.case_id %}">{{ case_run.case_id }}</a>
+							<a href="{% url "testcases-get" case_run.case_id %}">{{ case_run.case_id }}</a>
 							<input type="hidden" name="case" value="{{ case_run.case_id }}">
                             <input type="hidden" name="case_run_id" value="{{ case_run.case_run_id }}">
 						</td>

--- a/tcms/templates/run/clone_multiple.html
+++ b/tcms/templates/run/clone_multiple.html
@@ -16,7 +16,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 {% block contents %}
 <div id="content">
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">Test Runs</a>
 		>> Clone mulitple
 	</div>

--- a/tcms/templates/run/clone_multiple.html
+++ b/tcms/templates/run/clone_multiple.html
@@ -17,11 +17,11 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 <div id="content">
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">Test Runs</a>
+		>> <a href="{% url "plans-all" %}">Test Runs</a>
 		>> Clone mulitple
 	</div>
 
-	<form action="{% url "tcms.testruns.views.clone" %}" method="post">
+	<form action="{% url "testruns-clone" %}" method="post">
 		<div class="boxnotype">
         	<div class="boxtitle">The runs you have choosed</div>
 				{{ clone_form.run }}

--- a/tcms/templates/run/common/json_runs.txt
+++ b/tcms/templates/run/common/json_runs.txt
@@ -6,11 +6,11 @@
 	{% for run in runs %}
 	[
 		"<input type='checkbox' name='run' value='{{  run.pk  }}' class='run_selector'>",
-		"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{  run.run_id  }}</a>",
-		"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{  run.summary  }}</a>",
-		"<a href='{% url "tcms.profiles.views.profile" run.manager.username %}'>{{  run.manager  }}</a>",
+		"<a href='{% url "testruns-get" run.run_id %}' >{{  run.run_id  }}</a>",
+		"<a href='{% url "testruns-get" run.run_id %}' >{{  run.summary  }}</a>",
+		"<a href='{% url "tcms-profile" run.manager.username %}'>{{  run.manager  }}</a>",
 		{% if run.default_tester_id %}
-			"<a href='{% url "tcms.profiles.views.profile" run.default_tester.username %}'>{{ run.default_tester }}</a>"
+			"<a href='{% url "tcms-profile" run.default_tester.username %}'>{{ run.default_tester }}</a>"
 		{% else %}
 			"{{ run.default_tester }}"
 		{% endif %},

--- a/tcms/templates/run/common/run_advance_filtered.html
+++ b/tcms/templates/run/common/run_advance_filtered.html
@@ -19,10 +19,10 @@
 		{% for test_run in test_runs %}
 		<tr class="{% cycle 'rowodd' 'roweven' %}" id="run_{{test_run.run_id}}">
 			<td><input type='checkbox' name="run" value="{{ test_run.pk }}" class="run_selector" /></td>
-			<td><a href="{% url "tcms.testruns.views.get" test_run.run_id %}" >{{ test_run.run_id }}</a></td>
-			<td><a href="{% url "tcms.testruns.views.get" test_run.run_id %}" >{{ test_run.summary }}</a></td>
-			<td><a href="{% url "tcms.profiles.views.profile" test_run.manager.username %}">{{ test_run.manager }}</a></td>
-			<td>{% if test_run.default_tester_id %}<a href="{% url "tcms.profiles.views.profile" test_run.default_tester.username %}">{% endif %}{{ test_run.default_tester }}{% if test_run.default_tester_id %}</a>{% endif %}</td>
+			<td><a href="{% url "testruns-get" test_run.run_id %}" >{{ test_run.run_id }}</a></td>
+			<td><a href="{% url "testruns-get" test_run.run_id %}" >{{ test_run.summary }}</a></td>
+			<td><a href="{% url "tcms-profile" test_run.manager.username %}">{{ test_run.manager }}</a></td>
+			<td>{% if test_run.default_tester_id %}<a href="{% url "tcms-profile" test_run.default_tester.username %}">{% endif %}{{ test_run.default_tester }}{% if test_run.default_tester_id %}</a>{% endif %}</td>
 			<td style="display:none" class="col_plan_content"><a href="{{ test_run.plan.get_absolute_url }}" >{{ test_run.plan }}</a></td>
 			<td>{{ test_run.build.product }}</td>
 			<td>{{ test_run.product_version }}</td>

--- a/tcms/templates/run/edit.html
+++ b/tcms/templates/run/edit.html
@@ -29,7 +29,7 @@
 		<input id="value_product_id" type="hidden" name="product_id" value="{{ test_run.product_id }}" />
 	</div>
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if request.REQUEST.from_plan %}
 		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
 		>> <a href="{{ test_run.plan.get_absolute_url }}">Test Plan :{{ test_run.plan.plan_id }}: {{ test_run.plan }}</a>

--- a/tcms/templates/run/edit.html
+++ b/tcms/templates/run/edit.html
@@ -31,12 +31,12 @@
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
 		{% if request.REQUEST.from_plan %}
-		>> <a href="{% url "tcms.testplans.views.all" %}">Planning</a>
+		>> <a href="{% url "plans-all" %}">Planning</a>
 		>> <a href="{{ test_run.plan.get_absolute_url }}">Test Plan :{{ test_run.plan.plan_id }}: {{ test_run.plan }}</a>
 		{% else %}
-		>> <a href="{% url "tcms.testruns.views.all" %}">Test Runs</a>
+		>> <a href="{% url "testruns-all" %}">Test Runs</a>
 		{% endif %}
-		>> <a href="{% url "tcms.testruns.views.get" test_run.run_id %}">{{ test_run.run_id }}: {{ test_run }}</a> >>Edit
+		>> <a href="{% url "testruns-get" test_run.run_id %}">{{ test_run.run_id }}: {{ test_run }}</a> >>Edit
 	</div>
 	<h2>Edit Test Run</h2>
 	<form action="{% url "tcms.testruns.views.edit" test_run.run_id %}" method="post">
@@ -162,7 +162,7 @@
 		<div id="control_box" class="submit-row">
 			<input type="submit" value="Save" />
 			<input type="reset" value="Reset" />
-			<input type="button" value="Back" onclick="window.location.href='{% url "tcms.testruns.views.get" test_run.run_id %}'" />
+			<input type="button" value="Back" onclick="window.location.href='{% url "testruns-get" test_run.run_id %}'" />
 		</div>
 	</div>
 	</form>

--- a/tcms/templates/run/get.html
+++ b/tcms/templates/run/get.html
@@ -37,7 +37,7 @@ jQ(function() {
 		<input id="value_product_id" type="hidden" name="product_id" value="{{ test_run.build.product_id }}" />
 	</div>
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		{% if request.REQUEST.from_plan %}
 		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">Seach Plan</a>
 		&gt;&gt; Test Plan: <a href="{{ test_run.plan.get_absolute_url }}">[{{ test_run.plan.plan_id }}] {{ test_run.plan.name }}</a>

--- a/tcms/templates/run/get.html
+++ b/tcms/templates/run/get.html
@@ -39,10 +39,10 @@ jQ(function() {
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
 		{% if request.REQUEST.from_plan %}
-		&gt;&gt; <a href="{% url "tcms.testplans.views.all" %}">Seach Plan</a>
+		&gt;&gt; <a href="{% url "plans-all" %}">Seach Plan</a>
 		&gt;&gt; Test Plan: <a href="{{ test_run.plan.get_absolute_url }}">[{{ test_run.plan.plan_id }}] {{ test_run.plan.name }}</a>
 		{% else %}
-		&gt;&gt; <a href="{% url "tcms.testruns.views.all" %}">Search Runs</a>
+		&gt;&gt; <a href="{% url "testruns-all" %}">Search Runs</a>
 		{% endif %}
 		&gt;&gt; [{{ test_run.run_id }}] {{ test_run.summary }}
 	</div>
@@ -83,13 +83,13 @@ jQ(function() {
 			<div class="listinfo">
 				<div class="title grey">Product Version&nbsp;:</div>
 				<div class="name">
-					<a href="{% url "tcms.testruns.views.all" %}?product={{ test_run.build.product_id }}&product_version={{ test_run.product_version_id }}" title="Search test runs of {{ test_run.product_version }}">{{ test_run.product_version }}</a>
+					<a href="{% url "testruns-all" %}?product={{ test_run.build.product_id }}&product_version={{ test_run.product_version_id }}" title="Search test runs of {{ test_run.product_version }}">{{ test_run.product_version }}</a>
 				</div>
 			</div>
 			<div class="listinfo">
 				<div class="title grey">Manager&nbsp;:</div>
 				<div class="name">
-					<a href="{% url "tcms.profiles.views.profile" test_run.manager.username %}">{{ test_run.manager.email }}</a>
+					<a href="{% url "tcms-profile" test_run.manager.username %}">{{ test_run.manager.email }}</a>
 				</div>
 			</div>
 			<div class="listinfo">
@@ -138,13 +138,13 @@ jQ(function() {
 			<div class="listinfo">
 				<div class="title grey">Product&nbsp;:</div>
 				<div class="name">
-					<a href="{% url "tcms.testruns.views.all" %}?product={{ test_run.product_version.product_id }}" title="Search test runs of {{ test_run.product_version.product }}">{{ test_run.product_version.product }}</a>
+					<a href="{% url "testruns-all" %}?product={{ test_run.product_version.product_id }}" title="Search test runs of {{ test_run.product_version.product }}">{{ test_run.product_version.product }}</a>
 				</div>
 			</div>
 			<div class="listinfo">
 				<div class="title grey">Build&nbsp;:</div>
 				<div class="name">
-					<a href="{% url "tcms.testruns.views.all" %}?build={{ test_run.build_id }}" title="Search test runs of {{ test_run.build_id }}">{{ test_run.build }}</a>
+					<a href="{% url "testruns-all" %}?build={{ test_run.build_id }}" title="Search test runs of {{ test_run.build_id }}">{{ test_run.build }}</a>
 				</div>
 			</div>
                         {% if errata_url_prefix and test_run.errata_id %}
@@ -159,7 +159,7 @@ jQ(function() {
 				<div class="title grey">Default Tester&nbsp;:</div>
 				<div class="name">
 					{% if test_run.default_tester %}
-					<a href="{% url "tcms.profiles.views.profile" test_run.default_tester.username %}">{{ test_run.default_tester.email }}</a>
+					<a href="{% url "tcms-profile" test_run.default_tester.username %}">{{ test_run.default_tester.email }}</a>
 					{% else %}
 					{{ test_run.default_tester }}
 					{% endif %}

--- a/tcms/templates/run/new.html
+++ b/tcms/templates/run/new.html
@@ -30,7 +30,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.New.on_load);
 		<input id="value_sub_module" type="hidden" name="sub_module" value="{{ sub_module }}" />
 	</div>
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="{% url "tcms.testplans.views.all" %}">...</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		>> New Test Run

--- a/tcms/templates/run/new.html
+++ b/tcms/templates/run/new.html
@@ -31,7 +31,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.New.on_load);
 	</div>
 	<div class="sprites crumble">
 		<a href="{% url "core-views-index" %}">Home</a>
-		>> <a href="{% url "tcms.testplans.views.all" %}">...</a>
+		>> <a href="{% url "plans-all" %}">...</a>
 		>> <a href="{{ test_plan.get_absolute_url }}">{{ test_plan.plan_id }}: {{ test_plan.name }}</a>
 		>> New Test Run
 	</div>

--- a/tcms/templates/run/report.html
+++ b/tcms/templates/run/report.html
@@ -14,7 +14,7 @@
 <body>
 	<div class="report_title">
 	Test Log Report
-	<div class="report_sub_title"><a href='{% url "tcms.testruns.views.get" test_run.run_id %}'>[{{ test_run.run_id }}] {{ test_run.summary }}</a></div></div>
+	<div class="report_sub_title"><a href='{% url "testruns-get" test_run.run_id %}'>[{{ test_run.run_id }}] {{ test_run.summary }}</a></div></div>
 	<div class="report_content">
 	<div id="content">
 		<div class="listinfo_content" style="float:left; width:95%">

--- a/tcms/templates/run/table_caseruns.html
+++ b/tcms/templates/run/table_caseruns.html
@@ -38,7 +38,7 @@
 				<a href="#caserun_{{ test_case_run.pk }}">#{{ test_case_run.pk }}</a>
 			</td>
 			<td "{{ test_case_run.case_id }}" class="case_title expandable">
-				<a href="{% url "tcms.testcases.views.get" test_case_run.case_id %}?from_plan={{ test_case_run.run.plan_id }}">{{ test_case_run.case_id }}</a>
+				<a href="{% url "testcases-get" test_case_run.case_id %}?from_plan={{ test_case_run.run.plan_id }}">{{ test_case_run.case_id }}</a>
 			</td>
 			
 			<td class="expandable">
@@ -46,14 +46,14 @@
 			</td>
 			<td>
 				{% if tester %}
-				<a href="{% url "tcms.profiles.views.profile" tester %}" class="link_tested_by">{{ tester }}</a>
+				<a href="{% url "tcms-profile" tester %}" class="link_tested_by">{{ tester }}</a>
 				{% else %}
 				<a class="link_tested_by">None</a>
 				{% endif %}
 			</td>
 			<td>
 				{% if assignee %}
-				<a href="{% url "tcms.profiles.views.profile" assignee %}" class="link_assignee">{{ assignee }}</a>
+				<a href="{% url "tcms-profile" assignee %}" class="link_assignee">{{ assignee }}</a>
 				{% else %}None{% endif %}
 			</td>
 			<td class="expandable">{{ test_case_run.case.get_is_automated_status }}</td>

--- a/tcms/templates/search/advanced_search.html
+++ b/tcms/templates/search/advanced_search.html
@@ -12,7 +12,7 @@
 
 {% block contents %}
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> Advanced Search
 	</div>
 	<div class="advancedSearchTip advancedSearch">

--- a/tcms/templates/search/cases.html
+++ b/tcms/templates/search/cases.html
@@ -1,8 +1,8 @@
 <script type="text/javascript" src='{{ STATIC_URL }}js/testcase_actions.js'></script>
 <script type="text/javascript" language="javascript" charset="utf-8">
 	Nitrate.TestCases.List.Param = {
-		'case_printable': '{% url "tcms.testcases.views.printable" %}',
-		'case_export':'{% url "tcms.testcases.views.export" %}'
+		'case_printable': '{% url "testcases-printable" %}',
+		'case_export':'{% url "testcases-export" %}'
 	};
 	Nitrate.Utils.after_page_load(Nitrate.TestCases.AdvanceList.on_load);
 </script>

--- a/tcms/templates/search/results.html
+++ b/tcms/templates/search/results.html
@@ -13,7 +13,7 @@
 
 {% block contents %}
 	<div class="sprites crumble">
-		<a href="{% url "tcms.core.views.index" %}">Home</a>
+		<a href="{% url "core-views-index" %}">Home</a>
 		>> <a href="/advance-search/">Advanced Search</a>
 		>> Search Results
 	</div>

--- a/tcms/templates/search/runs.html
+++ b/tcms/templates/search/runs.html
@@ -8,8 +8,8 @@
 <form id='runs_form'>
 	{% autopaginate test_runs %}
 	<div id="contentTab" class="mixbar">
-		<span class="tit"><a href="{% url "tcms.testruns.views.all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
-		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param="{% url "tcms.testruns.views.clone" %}" />
+		<span class="tit"><a href="{% url "testruns-all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
+		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param="{% url "testruns-clone" %}" />
 		<span class="right-action">{% paginate %}</span>
 	</div>
 	{% include "run/common/run_advance_filtered.html" %}

--- a/tcms/templates/tcms_base.html
+++ b/tcms/templates/tcms_base.html
@@ -101,25 +101,25 @@
 		<div class="absoluteright">
 		<label>
 			{% if user.is_authenticated %}
-			<a href="{% url "tcms.profiles.views.profile" user.username %}">Welcome, {{ user }}</a>
+			<a href="{% url "tcms-profile" user.username %}">Welcome, {{ user }}</a>
 			{% if AUTH_BACKEND.can_logout %}
-			<span>[</span><a href="{% url "tcms.core.contrib.auth.views.logout" %}?next={{ request.path }}">Logout</a><span>]</span>
+			<span>[</span><a href="{% url "tcms-logout" %}?next={{ request.path }}">Logout</a><span>]</span>
 			{% endif %}
 			{% else %}
 			Welcome, Guest.
 			[
 			{% if AUTH_BACKEND.can_login %}
-			<a href="{% url "django.contrib.auth.views.login" %}?next={{ request.path }}" class="banner_login">Login</a>
+			<a href="{% url "tcms-login" %}?next={{ request.path }}" class="banner_login">Login</a>
 			{% endif %}
 			{% if AUTH_BACKEND.can_register %}
-			<a href="{% url "tcms.core.contrib.auth.views.register" %}?next={{ request.path }}" class="banner_login">Register</a>
+			<a href="{% url "tcms-register" %}?next={{ request.path }}" class="banner_login">Register</a>
 			{% endif %}
 			]
 			{% endif %}
 			<a class="sprites userguide" href="{{ SETTINGS.USER_GUIDE_URL }}" target="_blank">User Guide</a>
 		</label>
 		{% if user.is_authenticated %}
-		<form id="id_bookmark_iform" action="{% url "tcms.profiles.views.bookmark" user.username %}" method="get">
+		<form id="id_bookmark_iform" action="{% url "tcms-bookmark" user.username %}" method="get">
 			<input type="hidden" name="a" value="render_form" />
 			<input type="hidden" name="user" value="{{ request.user.pk }}" />
 			<input type="hidden" name="site" value="{{ SETTINGS.SITE_ID }}" />

--- a/tcms/templates/tcms_base.html
+++ b/tcms/templates/tcms_base.html
@@ -96,7 +96,7 @@
 <body id="body">
 	<div id="header">
                 <div class="logo">
-                    <a href="{% url "tcms.core.views.index" %}"><img src="{{ STATIC_URL }}images/kiwi_h50.png" alt="logo" /></a>
+                    <a href="{% url "core-views-index" %}"><img src="{{ STATIC_URL }}images/kiwi_h50.png" alt="logo" /></a>
                 </div>
 		<div class="absoluteright">
 		<label>

--- a/tcms/testcases/models.py
+++ b/tcms/testcases/models.py
@@ -545,7 +545,7 @@ class TestCase(TCMSActionModel):
         self.tag.through.objects.filter(case=self.pk, tag=tag.pk).delete()
 
     def get_url_path(self, request=None):
-        return reverse('tcms.testcases.views.get', args=[self.pk, ])
+        return reverse('testcases-get', args=[self.pk, ])
 
     def _get_email_conf(self):
         try:

--- a/tcms/testcases/tests.py
+++ b/tcms/testcases/tests.py
@@ -284,7 +284,7 @@ class TestOperateComponentView(BasePlanCase):
 
         user_should_have_perm(cls.tester, 'testcases.add_testcasecomponent')
 
-        cls.cases_component_url = reverse('tcms.testcases.views.component')
+        cls.cases_component_url = reverse('testcases-component')
 
     def setUp(self):
         self.client = Client()
@@ -378,7 +378,7 @@ class TestOperateCategoryView(BasePlanCase):
 
         user_should_have_perm(cls.tester, 'testcases.add_testcasecomponent')
 
-        cls.case_category_url = reverse('tcms.testcases.views.category')
+        cls.case_category_url = reverse('testcases-category')
 
     def setUp(self):
         self.client = Client()
@@ -435,7 +435,7 @@ class TestAddIssueToCase(BasePlanCase):
                                                    password='password')
         user_should_have_perm(cls.plan_tester, 'testcases.change_testcasebug')
 
-        cls.case_bug_url = reverse('tcms.testcases.views.bug', args=[cls.case_1.pk])
+        cls.case_bug_url = reverse('testcases-bug', args=[cls.case_1.pk])
         cls.issue_tracker = TestCaseBugSystem.objects.get(name='Bugzilla')
 
     def test_add_and_remove_a_bug(self):
@@ -494,7 +494,7 @@ class TestOperateCasePlans(BasePlanCase):
                                                    email='plantester@example.com',
                                                    password='password')
 
-        cls.case_plans_url = reverse('tcms.testcases.views.plan', args=[cls.case_1.pk])
+        cls.case_plans_url = reverse('testcases-plan', args=[cls.case_1.pk])
 
     def tearDown(self):
         remove_perm_from_user(self.plan_tester, 'testcases.add_testcaseplan')
@@ -554,7 +554,7 @@ class TestOperateCasePlans(BasePlanCase):
         user_should_have_perm(self.plan_tester, 'testcases.add_testcaseplan')
         self.client.login(username=self.plan_tester.username, password='password')
         # This time, add a few plans to another case
-        url = reverse('tcms.testcases.views.plan', args=[self.case_2.pk])
+        url = reverse('testcases-plan', args=[self.case_2.pk])
 
         response = self.client.get(url,
                                    {'a': 'add', 'plan_id': [self.plan_test_add.pk,
@@ -585,7 +585,7 @@ class TestOperateCaseTag(BasePlanCase):
         TestCaseTagFactory(case=cls.case_3, tag=cls.tag_rhel)
         TestCaseTagFactory(case=cls.case_3, tag=cls.tag_python)
 
-        cls.cases_tag_url = reverse('tcms.testcases.views.tag')
+        cls.cases_tag_url = reverse('testcases-tag')
 
     def test_show_cases_list(self):
         response = self.client.post(self.cases_tag_url,

--- a/tcms/testcases/urls/__init__.py
+++ b/tcms/testcases/urls/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
+from . import case_urls
+from . import cases_urls

--- a/tcms/testcases/urls/case_urls.py
+++ b/tcms/testcases/urls/case_urls.py
@@ -1,37 +1,29 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
-from tcms.testcases.views import SimpleTestCaseView
-from tcms.testcases.views import TestCaseCaseRunDetailPanelView
-from tcms.testcases.views import TestCaseCaseRunListPaneView
-from tcms.testcases.views import TestCaseReviewPaneView
-from tcms.testcases.views import TestCaseSimpleCaseRunView
+from .. import views
+from tcms.testruns.views import load_runs_of_one_plan
 
-urlpatterns = patterns(
-    'tcms.testcases.views',
-    url(r'^(?P<case_id>\d+)/$', 'get'),
-    url(r'^(?P<case_id>\d+)/edit/$', 'edit'),
-    url(r'^(?P<case_id>\d+)/history/$', 'text_history'),
-    url(r'^(?P<case_id>\d+)/attachment/$', 'attachment'),
-    url(r'^(?P<case_id>\d+)/log/$', 'get_log'),
-    url(r'^(?P<case_id>\d+)/bug/$', 'bug'),
-    url(r'^(?P<case_id>\d+)/plan/$', 'plan'),
-    url(r'^(?P<case_id>\d+)/readonly-pane/$', SimpleTestCaseView.as_view(),
+urlpatterns = [
+    url(r'^(?P<case_id>\d+)/$', views.get),
+    url(r'^(?P<case_id>\d+)/edit/$', views.edit),
+    url(r'^(?P<case_id>\d+)/history/$', views.text_history),
+    url(r'^(?P<case_id>\d+)/attachment/$', views.attachment),
+    url(r'^(?P<case_id>\d+)/log/$', views.get_log),
+    url(r'^(?P<case_id>\d+)/bug/$', views.bug),
+    url(r'^(?P<case_id>\d+)/plan/$', views.plan),
+    url(r'^(?P<case_id>\d+)/readonly-pane/$', views.SimpleTestCaseView.as_view(),
         name='case-readonly-pane'),
-    url(r'^(?P<case_id>\d+)/review-pane/$', TestCaseReviewPaneView.as_view(),
+    url(r'^(?P<case_id>\d+)/review-pane/$', views.TestCaseReviewPaneView.as_view(),
         name='case-review-pane'),
-    url(r'^(?P<case_id>\d+)/caserun-list-pane/$', TestCaseCaseRunListPaneView.as_view(),
+    url(r'^(?P<case_id>\d+)/caserun-list-pane/$', views.TestCaseCaseRunListPaneView.as_view(),
         name='caserun-list-pane'),
-    url(r'^(?P<case_id>\d+)/caserun-simple-pane/$', TestCaseSimpleCaseRunView.as_view(),
+    url(r'^(?P<case_id>\d+)/caserun-simple-pane/$', views.TestCaseSimpleCaseRunView.as_view(),
         name='caserun-simple-pane'),
-    url(r'^(?P<case_id>\d+)/caserun-detail-pane/$', TestCaseCaseRunDetailPanelView.as_view(),
+    url(r'^(?P<case_id>\d+)/caserun-detail-pane/$', views.TestCaseCaseRunDetailPanelView.as_view(),
         name='caserun-detail-pane'),
-)
 
-
-urlpatterns += patterns(
-    'tcms.testruns.views',
-    url(r'^(?P<plan_id>\d+)/runs/$', 'load_runs_of_one_plan',
+    url(r'^(?P<plan_id>\d+)/runs/$', load_runs_of_one_plan,
         name='load_runs_of_one_plan_url'),
-)
+]

--- a/tcms/testcases/urls/case_urls.py
+++ b/tcms/testcases/urls/case_urls.py
@@ -6,13 +6,13 @@ from .. import views
 from tcms.testruns.views import load_runs_of_one_plan
 
 urlpatterns = [
-    url(r'^(?P<case_id>\d+)/$', views.get),
+    url(r'^(?P<case_id>\d+)/$', views.get, name='testcases-get'),
     url(r'^(?P<case_id>\d+)/edit/$', views.edit),
-    url(r'^(?P<case_id>\d+)/history/$', views.text_history),
-    url(r'^(?P<case_id>\d+)/attachment/$', views.attachment),
+    url(r'^(?P<case_id>\d+)/history/$', views.text_history, name='testcases-text_history'),
+    url(r'^(?P<case_id>\d+)/attachment/$', views.attachment, name='testcases-attachment'),
     url(r'^(?P<case_id>\d+)/log/$', views.get_log),
-    url(r'^(?P<case_id>\d+)/bug/$', views.bug),
-    url(r'^(?P<case_id>\d+)/plan/$', views.plan),
+    url(r'^(?P<case_id>\d+)/bug/$', views.bug, name='testcases-bug'),
+    url(r'^(?P<case_id>\d+)/plan/$', views.plan, name='testcases-plan'),
     url(r'^(?P<case_id>\d+)/readonly-pane/$', views.SimpleTestCaseView.as_view(),
         name='case-readonly-pane'),
     url(r'^(?P<case_id>\d+)/review-pane/$', views.TestCaseReviewPaneView.as_view(),

--- a/tcms/testcases/urls/cases_urls.py
+++ b/tcms/testcases/urls/cases_urls.py
@@ -5,16 +5,16 @@ from django.conf.urls import url
 from .. import views
 
 urlpatterns = [
-    url(r'^new/$', views.new),
-    url(r'^$', views.all),
-    url(r'^search/$', views.search),
+    url(r'^new/$', views.new, name='testcases-new'),
+    url(r'^$', views.all, name='testcases-all'),
+    url(r'^search/$', views.search, name='testcases-search'),
     url(r'^load-more/$', views.load_more_cases),
     url(r'^ajax/$', views.ajax_search),
     url(r'^automated/$', views.automated),
-    url(r'^tag/$', views.tag),
-    url(r'^component/$', views.component),
-    url(r'^category/$', views.category),
-    url(r'^clone/$', views.clone),
-    url(r'^printable/$', views.printable),
-    url(r'^export/$', views.export),
+    url(r'^tag/$', views.tag, name='testcases-tag'),
+    url(r'^component/$', views.component, name='testcases-component'),
+    url(r'^category/$', views.category, name='testcases-category'),
+    url(r'^clone/$', views.clone, name='testcases-clone'),
+    url(r'^printable/$', views.printable, name='testcases-printable'),
+    url(r'^export/$', views.export, name='testcases-export'),
 ]

--- a/tcms/testcases/urls/cases_urls.py
+++ b/tcms/testcases/urls/cases_urls.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'tcms.testcases.views',
-    url(r'^new/$', 'new'),
-    url(r'^$', 'all'),
-    url(r'^search/$', 'search'),
-    url(r'^load-more/$', 'load_more_cases'),
-    url(r'^ajax/$', 'ajax_search'),
-    url(r'^automated/$', 'automated'),
-    url(r'^tag/$', 'tag'),
-    url(r'^component/$', 'component'),
-    url(r'^category/$', 'category'),
-    url(r'^clone/$', 'clone'),
-    url(r'^printable/$', 'printable'),
-    url(r'^export/$', 'export'),
-)
+from .. import views
+
+urlpatterns = [
+    url(r'^new/$', views.new),
+    url(r'^$', views.all),
+    url(r'^search/$', views.search),
+    url(r'^load-more/$', views.load_more_cases),
+    url(r'^ajax/$', views.ajax_search),
+    url(r'^automated/$', views.automated),
+    url(r'^tag/$', views.tag),
+    url(r'^component/$', views.component),
+    url(r'^category/$', views.category),
+    url(r'^clone/$', views.clone),
+    url(r'^printable/$', views.printable),
+    url(r'^export/$', views.export),
+]

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -227,19 +227,19 @@ def new(request, template_name='case/new.html'):
                 def _returntocase(self):
                     if self.plan:
                         return HttpResponseRedirect(
-                            '%s?from_plan=%s' % (reverse('tcms.testcases.views.get',
+                            '%s?from_plan=%s' % (reverse('testcases-get',
                                                          args=[self.case.pk]),
                                                  self.plan.plan_id))
 
                     return HttpResponseRedirect(
-                        reverse('tcms.testcases.views.get', args=[self.case.pk]))
+                        reverse('testcases-get', args=[self.case.pk]))
 
                 def _returntoplan(self):
                     if not self.plan:
                         raise Http404
 
                     return HttpResponseRedirect(
-                        '%s#reviewcases' % reverse('tcms.testplans.views.get',
+                        '%s#reviewcases' % reverse('test_plan_url_short',
                                                    args=[self.plan.pk]))
 
             # Genrate the instance of actions
@@ -1052,7 +1052,7 @@ def get(request, case_id, template_name='case/get.html'):
                 info_type=Prompt.Info,
                 info='''This case has been removed from the plan, but you
                           can view the case detail''',
-                next=reverse('tcms.testcases.views.get',
+                next=reverse('testcases-get',
                              args=[case_id, ]),
             ))
     else:
@@ -1357,15 +1357,15 @@ def edit(request, case_id, template_name='case/edit.html'):
                 confirm_status_name = 'CONFIRMED'
                 if tc.case_status.name == confirm_status_name:
                     return HttpResponseRedirect('%s#testcases' % (
-                        reverse('tcms.testplans.views.get', args=[tp.pk, ]),
+                        reverse('test_plan_url_short', args=[tp.pk, ]),
                     ))
                 else:
                     return HttpResponseRedirect('%s#reviewcases' % (
-                        reverse('tcms.testplans.views.get', args=[tp.pk, ]),
+                        reverse('test_plan_url_short', args=[tp.pk, ]),
                     ))
 
             return HttpResponseRedirect('%s?from_plan=%s' % (
-                reverse('tcms.testcases.views.get', args=[case_id, ]),
+                reverse('testcases-get', args=[case_id, ]),
                 request.REQUEST.get('from_plan', None),
             ))
 
@@ -1616,18 +1616,18 @@ def clone(request, template_name='case/clone.html'):
 
             if cases_count == 1 and plans_count == 1:
                 return HttpResponseRedirect('%s?from_plan=%s' % (
-                    reverse('tcms.testcases.views.get', args=[tc_dest.pk, ]),
+                    reverse('testcases-get', args=[tc_dest.pk, ]),
                     tp.pk
                 ))
 
             if cases_count == 1:
                 return HttpResponseRedirect(
-                    reverse('tcms.testcases.views.get', args=[tc_dest.pk, ])
+                    reverse('testcases-get', args=[tc_dest.pk, ])
                 )
 
             if plans_count == 1:
                 return HttpResponseRedirect(
-                    reverse('tcms.testplans.views.get', args=[tp.pk, ])
+                    reverse('test_plan_url_short', args=[tp.pk, ])
                 )
 
             # Otherwise it will prompt to user the clone action is successful.
@@ -1636,7 +1636,7 @@ def clone(request, template_name='case/clone.html'):
                 info_type=Prompt.Info,
                 info='Test case successful to clone, click following link '
                      'to return to plans page.',
-                next=reverse('tcms.testplans.views.all')
+                next=reverse('plans-all')
             ))
     else:
         selected_cases = get_selected_testcases(request)

--- a/tcms/testplans/tests.py
+++ b/tcms/testplans/tests.py
@@ -65,22 +65,22 @@ class PlanTests(test.TestCase):
         cls.plan_id = cls.test_plan.pk
 
     def test_open_plans_search(self):
-        location = reverse('tcms.testplans.views.all')
+        location = reverse('plans-all')
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_search_plans(self):
-        location = reverse('tcms.testplans.views.all')
+        location = reverse('plans-all')
         response = self.c.get(location, {'action': 'search', 'type': self.test_plan.type.pk})
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_plan_new_get(self):
-        location = reverse('tcms.testplans.views.new')
+        location = reverse('plans-new')
         response = self.c.get(location, follow=True)
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_plan_details(self):
-        location = reverse('tcms.testplans.views.get', args=[self.plan_id])
+        location = reverse('test_plan_url_short', args=[self.plan_id])
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.MOVED_PERMANENTLY)
 
@@ -88,12 +88,12 @@ class PlanTests(test.TestCase):
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_plan_cases(self):
-        location = reverse('tcms.testplans.views.cases', args=[self.plan_id])
+        location = reverse('plan-cases', args=[self.plan_id])
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_plan_importcase(self):
-        location = reverse('tcms.testplans.views.cases', args=[self.plan_id])
+        location = reverse('plan-cases', args=[self.plan_id])
         filename = os.path.join(TCMS_ROOT_PATH, 'fixtures', 'cases-to-import.xml')
         with open(filename, 'r') as fin:
             response = self.c.post(location, {'a': 'import_cases', 'xml_file': fin}, follow=True)
@@ -106,7 +106,7 @@ class PlanTests(test.TestCase):
     def test_plan_delete(self):
         tp_pk = self.test_plan.pk
 
-        location = reverse('tcms.testplans.views.delete', args=[tp_pk])
+        location = reverse('plan-delete', args=[tp_pk])
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
 
@@ -120,18 +120,18 @@ class PlanTests(test.TestCase):
                      'TestPlan {0} should be deleted. But, not.'.format(tp_pk))
 
     def test_plan_edit(self):
-        location = reverse('tcms.testplans.views.edit', args=[self.plan_id])
+        location = reverse('plan-edit', args=[self.plan_id])
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_plan_printable_without_selected_plan(self):
-        location = reverse('tcms.testplans.views.printable')
+        location = reverse('plans-printable')
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
         self.assertEqual(response.context['info'], 'At least one target is required.')
 
     def test_plan_printable(self):
-        location = reverse('tcms.testplans.views.printable')
+        location = reverse('plans-printable')
         response = self.c.get(location, {'plan': self.plan_id})
         self.assertEquals(response.status_code, httplib.OK)
 
@@ -152,13 +152,13 @@ class PlanTests(test.TestCase):
                 self.assertTrue(case.breakdown is not '')
 
     def test_plan_attachment(self):
-        location = reverse('tcms.testplans.views.attachment',
+        location = reverse('plan-attachment',
                            args=[self.plan_id])
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
 
     def test_plan_history(self):
-        location = reverse('tcms.testplans.views.text_history',
+        location = reverse('plan-text_history',
                            args=[self.plan_id])
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
@@ -216,7 +216,7 @@ class ExportTestPlanTests(test.TestCase):
             cls.cases.append(case)
 
     def test_export_returns_valid_xml_and_content(self):
-        location = reverse('tcms.testplans.views.export')
+        location = reverse('plans-export')
         response = self.c.get(location, {'plan': self.test_plan.pk})
         self.assertEquals(response.status_code, httplib.OK)
 
@@ -259,7 +259,7 @@ class ExportTestPlanTests(test.TestCase):
             self.assertEqual('component_for_%s' % summary, components[0].text.strip())
 
     def test_export_wo_parameters_returns_html_warning(self):
-        location = reverse('tcms.testplans.views.export')
+        location = reverse('plans-export')
         response = self.c.get(location)
         self.assertEquals(response.status_code, httplib.OK)
         self.assertIn('At least one target is required.', response.content)
@@ -291,7 +291,7 @@ class TestUnknownActionOnCases(BasePlanCase):
     """Test case for unknown action on a plan's cases"""
 
     def setUp(self):
-        self.cases_url = reverse('tcms.testplans.views.cases', args=[self.plan.pk])
+        self.cases_url = reverse('plan-cases', args=[self.plan.pk])
         self.client = Client()
 
     def test_ajax_request(self):
@@ -315,7 +315,7 @@ class TestDeleteCasesFromPlan(BasePlanCase):
         cls.plan_tester.save()
 
     def setUp(self):
-        self.cases_url = reverse('tcms.testplans.views.cases', args=[self.plan.pk])
+        self.cases_url = reverse('plan-cases', args=[self.plan.pk])
         self.client = Client()
         self.client.login(username=self.plan_tester.username, password='password')
 
@@ -360,7 +360,7 @@ class TestSortCases(BasePlanCase):
         cls.plan_tester.save()
 
     def setUp(self):
-        self.cases_url = reverse('tcms.testplans.views.cases', args=[self.plan.pk])
+        self.cases_url = reverse('plan-cases', args=[self.plan.pk])
         self.client = Client()
         self.client.login(username=self.plan_tester.username, password='password')
 
@@ -407,7 +407,7 @@ class TestLinkCases(BasePlanCase):
         cls.plan_tester.save()
 
     def setUp(self):
-        self.cases_url = reverse('tcms.testplans.views.cases', args=[self.plan.pk])
+        self.cases_url = reverse('plan-cases', args=[self.plan.pk])
         self.client = Client()
         self.client.login(username=self.plan_tester.username, password='password')
 
@@ -435,14 +435,14 @@ class TestLinkCases(BasePlanCase):
         self.assertContains(
             response,
             '<a href="{}">{}</a>'.format(
-                reverse('tcms.testcases.views.get', args=[self.another_case_2.pk]),
+                reverse('testcases-get', args=[self.another_case_2.pk]),
                 self.another_case_2.pk))
 
         # Assert: Do not list case that already belongs to the plan
         self.assertNotContains(
             response,
             '<a href="{}">{}</a>'.format(
-                reverse('tcms.testcases.views.get', args=[self.case_2.pk]),
+                reverse('testcases-get', args=[self.case_2.pk]),
                 self.case_2.pk))
 
     def test_quick_search(self):
@@ -476,7 +476,7 @@ class TestLinkCases(BasePlanCase):
 
         self.assertRedirects(
             response,
-            reverse('tcms.testplans.views.get', args=[self.plan.pk]),
+            reverse('test_plan_url_short', args=[self.plan.pk]),
             target_status_code=http_client.MOVED_PERMANENTLY)
 
         self.assertTrue(
@@ -530,7 +530,7 @@ class TestCloneView(BasePlanCase):
             email='tester@example.com',
             password='password')
         user_should_have_perm(cls.plan_tester, 'testplans.add_testplan')
-        cls.plan_clone_url = reverse('tcms.testplans.views.clone')
+        cls.plan_clone_url = reverse('plans-clone')
 
     def test_refuse_if_missing_a_plan(self):
         self.client.login(username=self.plan_tester.username, password='password')
@@ -664,7 +664,7 @@ class TestCloneView(BasePlanCase):
 
         self.assertRedirects(
             response,
-            reverse('tcms.testplans.views.get', args=[cloned_plan.pk]),
+            reverse('test_plan_url_short', args=[cloned_plan.pk]),
             target_status_code=http_client.MOVED_PERMANENTLY)
 
         self.verify_cloned_plan(self.third_plan, cloned_plan)
@@ -739,7 +739,7 @@ class TestCloneView(BasePlanCase):
         })
         self.assertRedirects(
             response,
-            '{}?{}'.format(reverse('tcms.testplans.views.all'), url_querystr))
+            '{}?{}'.format(reverse('plans-all'), url_querystr))
 
         for origin_plan in (self.plan, self.another_plan):
             cloned_plan = TestPlan.objects.get(name=origin_plan.make_cloned_name())

--- a/tcms/testplans/urls/__init__.py
+++ b/tcms/testplans/urls/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
+from . import plan_urls
+from . import plans_urls

--- a/tcms/testplans/urls/plan_urls.py
+++ b/tcms/testplans/urls/plan_urls.py
@@ -6,14 +6,14 @@ from .. import views
 from tcms.testruns.views import load_runs_of_one_plan
 
 urlpatterns = [
-    url(r'^(?P<plan_id>\d+)/$', views.get, name='test_plan_url'),
+    url(r'^(?P<plan_id>\d+)/$', views.get, name='test_plan_url_short'),
     url(r'^(?P<plan_id>\d+)/(?P<slug>[-\w\d]+)$', views.get, name='test_plan_url'),
-    url(r'^(?P<plan_id>\d+)/delete/$', views.delete),
+    url(r'^(?P<plan_id>\d+)/delete/$', views.delete, name='plan-delete'),
     url(r'^(?P<plan_id>\d+)/chooseruns/$', views.choose_run),
-    url(r'^(?P<plan_id>\d+)/edit/$', views.edit),
-    url(r'^(?P<plan_id>\d+)/attachment/$', views.attachment),
-    url(r'^(?P<plan_id>\d+)/history/$', views.text_history),
-    url(r'^(?P<plan_id>\d+)/cases/$', views.cases),
+    url(r'^(?P<plan_id>\d+)/edit/$', views.edit, name='plan-edit'),
+    url(r'^(?P<plan_id>\d+)/attachment/$', views.attachment, name='plan-attachment'),
+    url(r'^(?P<plan_id>\d+)/history/$', views.text_history, name='plan-text_history'),
+    url(r'^(?P<plan_id>\d+)/cases/$', views.cases, name='plan-cases'),
 
     url(r'^(?P<plan_id>\d+)/runs/$', load_runs_of_one_plan, name='load_runs_of_one_plan_url')
 ]

--- a/tcms/testplans/urls/plan_urls.py
+++ b/tcms/testplans/urls/plan_urls.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'tcms.testplans.views',
-    url(r'^(?P<plan_id>\d+)/$', 'get', name='test_plan_url'),
-    url(r'^(?P<plan_id>\d+)/(?P<slug>[-\w\d]+)$', 'get', name='test_plan_url'),
-    url(r'^(?P<plan_id>\d+)/delete/$', 'delete'),
-    url(r'^(?P<plan_id>\d+)/chooseruns/$', 'choose_run'),
-    url(r'^(?P<plan_id>\d+)/edit/$', 'edit'),
-    url(r'^(?P<plan_id>\d+)/attachment/$', 'attachment'),
-    url(r'^(?P<plan_id>\d+)/history/$', 'text_history'),
-    url(r'^(?P<plan_id>\d+)/cases/$', 'cases'),
-)
+from .. import views
+from tcms.testruns.views import load_runs_of_one_plan
 
-urlpatterns += patterns(
-    'tcms.testruns.views',
-    url(r'^(?P<plan_id>\d+)/runs/$', 'load_runs_of_one_plan',
-        name='load_runs_of_one_plan_url'),
-)
+urlpatterns = [
+    url(r'^(?P<plan_id>\d+)/$', views.get, name='test_plan_url'),
+    url(r'^(?P<plan_id>\d+)/(?P<slug>[-\w\d]+)$', views.get, name='test_plan_url'),
+    url(r'^(?P<plan_id>\d+)/delete/$', views.delete),
+    url(r'^(?P<plan_id>\d+)/chooseruns/$', views.choose_run),
+    url(r'^(?P<plan_id>\d+)/edit/$', views.edit),
+    url(r'^(?P<plan_id>\d+)/attachment/$', views.attachment),
+    url(r'^(?P<plan_id>\d+)/history/$', views.text_history),
+    url(r'^(?P<plan_id>\d+)/cases/$', views.cases),
+
+    url(r'^(?P<plan_id>\d+)/runs/$', load_runs_of_one_plan, name='load_runs_of_one_plan_url')
+]

--- a/tcms/testplans/urls/plan_urls.py
+++ b/tcms/testplans/urls/plan_urls.py
@@ -7,7 +7,11 @@ from tcms.testruns.views import load_runs_of_one_plan
 
 urlpatterns = [
     url(r'^(?P<plan_id>\d+)/$', views.get, name='test_plan_url_short'),
+    # for compatibility with core.views.search.search()
+    url(r'^(?P<plan_id>\d+)/$', views.get, name='testplans-get'),
+    # human friendly url
     url(r'^(?P<plan_id>\d+)/(?P<slug>[-\w\d]+)$', views.get, name='test_plan_url'),
+
     url(r'^(?P<plan_id>\d+)/delete/$', views.delete, name='plan-delete'),
     url(r'^(?P<plan_id>\d+)/chooseruns/$', views.choose_run),
     url(r'^(?P<plan_id>\d+)/edit/$', views.edit, name='plan-edit'),

--- a/tcms/testplans/urls/plans_urls.py
+++ b/tcms/testplans/urls/plans_urls.py
@@ -4,12 +4,12 @@ from django.conf.urls import url
 from .. import views
 
 urlpatterns = [
-    url(r'^$', views.all),
-    url(r'^new/$', views.new),
+    url(r'^$', views.all, name='plans-all'),
+    url(r'^new/$', views.new, name='plans-new'),
     url(r'^ajax/$', views.ajax_search),
     url(r'^treeview/$', views.tree_view),
-    url(r'^clone/$', views.clone),
-    url(r'^printable/$', views.printable),
-    url(r'^export/$', views.export),
+    url(r'^clone/$', views.clone, name='plans-clone'),
+    url(r'^printable/$', views.printable, name='plans-printable'),
+    url(r'^export/$', views.export, name='plans-export'),
     url(r'^component/$', views.component),
 ]

--- a/tcms/testplans/urls/plans_urls.py
+++ b/tcms/testplans/urls/plans_urls.py
@@ -5,6 +5,9 @@ from .. import views
 
 urlpatterns = [
     url(r'^$', views.all, name='plans-all'),
+    # for compatibility with with core.views.search.search()
+    url(r'^$', views.all, name='testplans-all'),
+
     url(r'^new/$', views.new, name='plans-new'),
     url(r'^ajax/$', views.ajax_search),
     url(r'^treeview/$', views.tree_view),

--- a/tcms/testplans/urls/plans_urls.py
+++ b/tcms/testplans/urls/plans_urls.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
+from .. import views
 
-urlpatterns = patterns(
-    'tcms.testplans.views',
-    url(r'^$', 'all'),
-    url(r'^new/$', 'new'),
-    url(r'^ajax/$', 'ajax_search'),
-    url(r'^treeview/$', 'tree_view'),
-    url(r'^clone/$', 'clone'),
-    url(r'^printable/$', 'printable'),
-    url(r'^export/$', 'export'),
-    url(r'^component/$', 'component'),
-)
+urlpatterns = [
+    url(r'^$', views.all),
+    url(r'^new/$', views.new),
+    url(r'^ajax/$', views.ajax_search),
+    url(r'^treeview/$', views.tree_view),
+    url(r'^clone/$', views.clone),
+    url(r'^printable/$', views.printable),
+    url(r'^export/$', views.export),
+    url(r'^component/$', views.component),
+]

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -127,7 +127,7 @@ def new(request, template_name='plan/new.html'):
             tp.emailing.save()
 
             return HttpResponseRedirect(
-                reverse('tcms.testplans.views.get', args=[tp.plan_id, ])
+                reverse('test_plan_url_short', args=[tp.plan_id, ])
             )
     else:
         form = NewPlanForm()
@@ -155,7 +155,7 @@ def delete(request, plan_id):
             } else { \
                 history.go(-1) \
             };</script>" % (plan_id, reverse(
-            'tcms.testplans.views.delete', args=[plan_id, ]
+            'plan-delete', args=[plan_id, ]
         ))
         )
     elif request.GET.get('sure') == 'yes':
@@ -165,7 +165,7 @@ def delete(request, plan_id):
             tp.delete()
             return HttpResponse(
                 "<script>window.location.href='%s'</script>" % reverse(
-                    'tcms.testplans.views.all')
+                    'plans-all')
             )
         except:
             return HttpResponse(Prompt.render(
@@ -569,7 +569,7 @@ def choose_run(request, plan_id, template_name='plan/choose_testrun.html'):
                 request=request,
                 info_type=Prompt.Info,
                 info='At least one test run and one case is required to add cases to runs.',
-                next=reverse('tcms.testplans.views.get', args=[plan_id]),
+                next=reverse('test_plan_url_short', args=[plan_id]),
             ))
 
         # Adding cases to runs by recursion
@@ -587,7 +587,7 @@ def choose_run(request, plan_id, template_name='plan/choose_testrun.html'):
             testrun.estimated_time = testrun.estimated_time + estimated_time
             testrun.save()
 
-        return HttpResponseRedirect(reverse('tcms.testplans.views.get', args=[plan_id]))
+        return HttpResponseRedirect(reverse('test_plan_url_short', args=[plan_id]))
 
 
 @require_http_methods(['GET', 'POST'])
@@ -663,7 +663,7 @@ def edit(request, plan_id, template_name='plan/edit.html'):
             # Update plan email settings
             update_plan_email_settings(tp, form)
             return HttpResponseRedirect(
-                reverse('tcms.testplans.views.get', args=[plan_id, slugify(tp.name)]))
+                reverse('test_plan_url', args=[plan_id, slugify(tp.name)]))
     else:
         # Generate a blank form
         # Temporary use one environment group in this case
@@ -785,7 +785,7 @@ def clone(request, template_name='plan/clone.html'):
 
             if len(tps) == 1:
                 return HttpResponseRedirect(
-                    reverse('tcms.testplans.views.get', args=[cloned_plan.plan_id]))
+                    reverse('test_plan_url_short', args=[cloned_plan.plan_id]))
             else:
                 args = {
                     'action': 'search',
@@ -794,7 +794,7 @@ def clone(request, template_name='plan/clone.html'):
                 }
                 url_args = urllib.urlencode(args)
                 return HttpResponseRedirect(
-                    '{}?{}'.format(reverse('tcms.testplans.views.all'), url_args))
+                    '{}?{}'.format(reverse('plans-all'), url_args))
     else:
         # Generate the default values for the form
         if len(tps) == 1:
@@ -902,7 +902,7 @@ def cases(request, plan_id):
                     return HttpResponse("Permission Denied")
 
                 return HttpResponseRedirect(
-                    reverse('tcms.testplans.views.get', args=[plan_id]))
+                    reverse('test_plan_url_short', args=[plan_id]))
 
             search_mode = request.POST.get('search_mode')
             if request.POST.get('action') == 'search':
@@ -988,7 +988,7 @@ def cases(request, plan_id):
                         request=request,
                         info_type=Prompt.Alert,
                         info='Permission denied',
-                        next=reverse('tcms.testplans.views.get', args=[plan_id]),
+                        next=reverse('test_plan_url_short', args=[plan_id]),
                     ))
 
                 xml_form = ImportCasesViaXMLForm(request.POST, request.FILES)
@@ -1040,17 +1040,17 @@ def cases(request, plan_id):
                         tc.add_to_plan(plan=tp)
 
                     return HttpResponseRedirect(
-                        reverse('tcms.testplans.views.get', args=[plan_id]) + '#testcases')
+                        reverse('test_plan_url_short', args=[plan_id]) + '#testcases')
                 else:
                     return HttpResponse(Prompt.render(
                         request=request,
                         info_type=Prompt.Alert,
                         info=xml_form.errors,
-                        next=reverse('tcms.testplans.views.get', args=[plan_id]) + '#testcases'
+                        next=reverse('test_plan_url_short', args=[plan_id]) + '#testcases'
                     ))
             else:
                 return HttpResponseRedirect(
-                    reverse('tcms.testplans.views.get', args=[plan_id]) + '#testcases')
+                    reverse('test_plan_url_short', args=[plan_id]) + '#testcases')
 
     # tp = get_object_or_404(TestPlan, plan_id=plan_id)
     cas = CaseActions(request, tp)
@@ -1067,7 +1067,7 @@ def cases(request, plan_id):
             request=request,
             info_type=Prompt.Alert,
             info='Unrecognizable actions',
-            next=reverse('tcms.testplans.views.get', args=[plan_id]),
+            next=reverse('test_plan_url_short', args=[plan_id]),
         ))
 
     func = getattr(cas, action)

--- a/tcms/testruns/models.py
+++ b/tcms/testruns/models.py
@@ -144,7 +144,7 @@ class TestRun(TCMSActionModel):
         # Upward compatibility code
         if request:
             return request.build_absolute_uri(
-                reverse('tcms.testruns.views.get', args=[self.pk, ])
+                reverse('testruns-get', args=[self.pk, ])
             )
 
         return self.get_url(request)
@@ -164,7 +164,7 @@ class TestRun(TCMSActionModel):
         return list(set(to))
 
     def get_url_path(self):
-        return reverse('tcms.testruns.views.get', args=[self.pk, ])
+        return reverse('testruns-get', args=[self.pk, ])
 
     # FIXME: rewrite to use multiple values INSERT statement
     def add_case_run(self, case, case_run_status=1, assignee=None,

--- a/tcms/testruns/tests.py
+++ b/tcms/testruns/tests.py
@@ -24,22 +24,22 @@ class TestOrderCases(BaseCaseRun):
 
     def test_404_if_run_does_not_exist(self):
         nonexisting_run_pk = TestRun.objects.last().pk + 1
-        url = reverse('tcms.testruns.views.order_case', args=[nonexisting_run_pk])
+        url = reverse('testruns-order_case', args=[nonexisting_run_pk])
         response = self.client.get(url)
         self.assertEqual(httplib.NOT_FOUND, response.status_code)
 
     def test_prompt_if_no_case_run_is_passed(self):
-        url = reverse('tcms.testruns.views.order_case', args=[self.test_run.pk])
+        url = reverse('testruns-order_case', args=[self.test_run.pk])
         response = self.client.get(url)
         self.assertIn('At least one case is required by re-oder in run', response.content)
 
     def test_order_case_runs(self):
-        url = reverse('tcms.testruns.views.order_case', args=[self.test_run.pk])
+        url = reverse('testruns-order_case', args=[self.test_run.pk])
         response = self.client.get(url, {'case_run': [self.case_run_1.pk,
                                                       self.case_run_2.pk,
                                                       self.case_run_3.pk]})
 
-        redirect_to = reverse('tcms.testruns.views.get', args=[self.test_run.pk])
+        redirect_to = reverse('testruns-get', args=[self.test_run.pk])
         self.assertRedirects(response, redirect_to)
 
         test_sortkeys = [

--- a/tcms/testruns/tests.py
+++ b/tcms/testruns/tests.py
@@ -7,33 +7,19 @@ from django.core.urlresolvers import reverse
 
 from tcms.testruns.models import TestRun
 from tcms.testruns.models import TestCaseRun
-from tcms.tests import BasePlanCase
-from tcms.tests.factories import TestRunFactory
-from tcms.tests.factories import TestBuildFactory
-from tcms.tests.factories import TestCaseRunFactory
+from tcms.tests import BaseCaseRun
 
 
 # ### Test case for View methods ###
 
 
-class TestOrderCases(BasePlanCase):
+class TestOrderCases(BaseCaseRun):
     """Test view method order_case"""
 
     @classmethod
     def setUpTestData(cls):
         super(TestOrderCases, cls).setUpTestData()
-        cls.build = TestBuildFactory(product=cls.product)
-        cls.test_run = TestRunFactory(product_version=cls.version, plan=cls.plan,
-                                      manager=cls.tester, default_tester=cls.tester)
-        cls.case_run_1 = TestCaseRunFactory(assignee=cls.tester, tested_by=cls.tester,
-                                            run=cls.test_run, case=cls.case_1, build=cls.build,
-                                            sortkey=101)
-        cls.case_run_2 = TestCaseRunFactory(assignee=cls.tester, tested_by=cls.tester,
-                                            run=cls.test_run, case=cls.case_2, build=cls.build,
-                                            sortkey=200)
-        cls.case_run_3 = TestCaseRunFactory(assignee=cls.tester, tested_by=cls.tester,
-                                            run=cls.test_run, case=cls.case_3, build=cls.build,
-                                            sortkey=300)
+
         cls.client = test.Client()
 
     def test_404_if_run_does_not_exist(self):

--- a/tcms/testruns/urls/__init__.py
+++ b/tcms/testruns/urls/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
+from . import run_urls
+from . import runs_urls

--- a/tcms/testruns/urls/run_urls.py
+++ b/tcms/testruns/urls/run_urls.py
@@ -1,30 +1,28 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
-from tcms.testruns.views import TestRunReportView
-from tcms.testruns.views import AddCasesToRunView
+from .. import views
 
-urlpatterns = patterns(
-    'tcms.testruns.views',
-    url(r'^new/$', 'new'),
-    url(r'^(?P<run_id>\d+)/$', 'get'),
-    url(r'^(?P<run_id>\d+)/clone/$', 'new_run_with_caseruns'),
-    url(r'^(?P<run_id>\d+)/delete/$', 'delete'),
-    url(r'^(?P<run_id>\d+)/edit/$', 'edit'),
+urlpatterns = [
+    url(r'^new/$', views.new),
+    url(r'^(?P<run_id>\d+)/$', views.get),
+    url(r'^(?P<run_id>\d+)/clone/$', views.new_run_with_caseruns),
+    url(r'^(?P<run_id>\d+)/delete/$', views.delete),
+    url(r'^(?P<run_id>\d+)/edit/$', views.edit),
 
-    url(r'^(?P<run_id>\d+)/report/$', TestRunReportView.as_view(),
+    url(r'^(?P<run_id>\d+)/report/$', views.TestRunReportView.as_view(),
         name='run-report'),
 
-    url(r'^(?P<run_id>\d+)/ordercase/$', 'order_case'),
-    url(r'^(?P<run_id>\d+)/changestatus/$', 'change_status'),
-    url(r'^(?P<run_id>\d+)/ordercaserun/$', 'order_case'),
-    url(r'^(?P<run_id>\d+)/removecaserun/$', 'remove_case_run'),
+    url(r'^(?P<run_id>\d+)/ordercase/$', views.order_case),
+    url(r'^(?P<run_id>\d+)/changestatus/$', views.change_status),
+    url(r'^(?P<run_id>\d+)/ordercaserun/$', views.order_case),
+    url(r'^(?P<run_id>\d+)/removecaserun/$', views.remove_case_run),
 
-    url(r'^(?P<run_id>\d+)/assigncase/$', AddCasesToRunView.as_view(),
+    url(r'^(?P<run_id>\d+)/assigncase/$', views.AddCasesToRunView.as_view(),
         name='add-cases-to-run'),
 
-    url(r'^(?P<run_id>\d+)/cc/$', 'cc'),
-    url(r'^(?P<run_id>\d+)/update/$', 'update_case_run_text'),
-    url(r'^(?P<run_id>\d+)/export/$', 'export'),
-)
+    url(r'^(?P<run_id>\d+)/cc/$', views.cc),
+    url(r'^(?P<run_id>\d+)/update/$', views.update_case_run_text),
+    url(r'^(?P<run_id>\d+)/export/$', views.export),
+]

--- a/tcms/testruns/urls/run_urls.py
+++ b/tcms/testruns/urls/run_urls.py
@@ -6,7 +6,7 @@ from .. import views
 
 urlpatterns = [
     url(r'^new/$', views.new),
-    url(r'^(?P<run_id>\d+)/$', views.get),
+    url(r'^(?P<run_id>\d+)/$', views.get, name='testruns-get'),
     url(r'^(?P<run_id>\d+)/clone/$', views.new_run_with_caseruns),
     url(r'^(?P<run_id>\d+)/delete/$', views.delete),
     url(r'^(?P<run_id>\d+)/edit/$', views.edit),
@@ -16,7 +16,7 @@ urlpatterns = [
 
     url(r'^(?P<run_id>\d+)/ordercase/$', views.order_case),
     url(r'^(?P<run_id>\d+)/changestatus/$', views.change_status),
-    url(r'^(?P<run_id>\d+)/ordercaserun/$', views.order_case),
+    url(r'^(?P<run_id>\d+)/ordercaserun/$', views.order_case, name='testruns-order_case'),
     url(r'^(?P<run_id>\d+)/removecaserun/$', views.remove_case_run),
 
     url(r'^(?P<run_id>\d+)/assigncase/$', views.AddCasesToRunView.as_view(),

--- a/tcms/testruns/urls/runs_urls.py
+++ b/tcms/testruns/urls/runs_urls.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
+from .. import views
 
-urlpatterns = patterns(
-    'tcms.testruns.views',
-    url(r'^$', 'all'),
-    url(r'^ajax/$', 'ajax_search'),
-    url(r'^env_value/$', 'env_value'),
-    url(r'^clone/$', 'clone'),
-)
+urlpatterns = [
+    url(r'^$', views.all),
+    url(r'^ajax/$', views.ajax_search),
+    url(r'^env_value/$', views.env_value),
+    url(r'^clone/$', views.clone),
+]

--- a/tcms/testruns/urls/runs_urls.py
+++ b/tcms/testruns/urls/runs_urls.py
@@ -4,8 +4,8 @@ from django.conf.urls import url
 from .. import views
 
 urlpatterns = [
-    url(r'^$', views.all),
+    url(r'^$', views.all, name='testruns-all'),
     url(r'^ajax/$', views.ajax_search),
     url(r'^env_value/$', views.env_value),
-    url(r'^clone/$', views.clone),
+    url(r'^clone/$', views.clone, name='testruns-clone'),
 ]

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -64,7 +64,7 @@ def new(request, template_name='run/new.html'):
 
     # If from_plan does not exist will redirect to plans for select a plan
     if not request.REQUEST.get('from_plan'):
-        return HttpResponseRedirect(reverse('tcms.testplans.views.all'))
+        return HttpResponseRedirect(reverse('plans-all'))
 
     plan_id = request.REQUEST.get('from_plan')
     # Case is required by a test run
@@ -73,7 +73,7 @@ def new(request, template_name='run/new.html'):
             request=request,
             info_type=Prompt.Info,
             info='At least one case is required by a run.',
-            next=reverse('tcms.testplans.views.get', args=[plan_id, ]),
+            next=reverse('test_plan_url_short', args=[plan_id, ]),
         ))
 
     # Ready to write cases to test plan
@@ -197,7 +197,7 @@ def new(request, template_name='run/new.html'):
                 TCMSEnvRunValueMap.objects.bulk_create(args)
 
             return HttpResponseRedirect(
-                reverse('tcms.testruns.views.get', args=[tr.run_id, ])
+                reverse('testruns-get', args=[tr.run_id, ])
             )
 
     else:
@@ -269,7 +269,7 @@ def delete(request, run_id):
             tr.case_run.all().delete()
             tr.delete()
             return HttpResponseRedirect(
-                reverse('tcms.testplans.views.get', args=(plan_id, ))
+                reverse('test_plan_url_short', args=(plan_id, ))
             )
         except:
             return HttpResponse(Prompt.render(
@@ -826,7 +826,7 @@ def edit(request, run_id, template_name='run/edit.html'):
                 tr.update_completion_status(is_auto_updated=False,
                                             is_finish=is_finish)
             return HttpResponseRedirect(
-                reverse('tcms.testruns.views.get', args=[run_id, ])
+                reverse('testruns-get', args=[run_id, ])
             )
     else:
         # Generate a blank form
@@ -1206,7 +1206,7 @@ def clone(request, template_name='run/clone.html'):
 
             if len(trs) == 1:
                 return HttpResponseRedirect(
-                    reverse('tcms.testruns.views.get', args=[n_tr.pk])
+                    reverse('testruns-get', args=[n_tr.pk])
                 )
 
             params = {
@@ -1215,7 +1215,7 @@ def clone(request, template_name='run/clone.html'):
                 'build': form.cleaned_data['build'].pk}
 
             return HttpResponseRedirect('%s?%s' % (
-                reverse('tcms.testruns.views.all'),
+                reverse('testruns-all'),
                 urllib.urlencode(params, True)
             ))
     else:
@@ -1253,7 +1253,7 @@ def order_case(request, run_id):
             request=request,
             info_type=Prompt.Info,
             info='At least one case is required by re-oder in run.',
-            next=reverse('tcms.testruns.views.get', args=[run_id, ]),
+            next=reverse('testruns-get', args=[run_id, ]),
         ))
 
     case_run_ids = request.REQUEST.getlist('case_run')
@@ -1277,7 +1277,7 @@ def order_case(request, run_id):
             cursor = connection.writer_cursor
             cursor.execute(sql, key_id_pair)
 
-    return HttpResponseRedirect(reverse('tcms.testruns.views.get', args=[run_id]))
+    return HttpResponseRedirect(reverse('testruns-get', args=[run_id]))
 
 
 @user_passes_test(lambda u: u.has_perm('testruns.change_testrun'))
@@ -1291,7 +1291,7 @@ def change_status(request, run_id):
         tr.update_completion_status(is_auto_updated=False, is_finish=False)
 
     return HttpResponseRedirect(
-        reverse('tcms.testruns.views.get', args=[run_id, ])
+        reverse('testruns-get', args=[run_id, ])
     )
 
 
@@ -1310,7 +1310,7 @@ def remove_case_run(request, run_id):
     # If no case run to remove, no further operation is required, just return
     # back to run page immediately.
     if not case_run_ids:
-        return HttpResponseRedirect(reverse('tcms.testruns.views.get',
+        return HttpResponseRedirect(reverse('testruns-get',
                                             args=[run_id, ]))
 
     run = get_object_or_404(TestRun.objects.only('pk'), pk=run_id)
@@ -1320,7 +1320,7 @@ def remove_case_run(request, run_id):
 
     caseruns_exist = TestCaseRun.objects.filter(run_id=run.pk).exists()
     if caseruns_exist:
-        redirect_to = 'tcms.testruns.views.get'
+        redirect_to = 'testruns-get'
     else:
         redirect_to = 'add-cases-to-run'
 
@@ -1394,7 +1394,7 @@ class AddCasesToRunView(View):
             for nc in ncs:
                 tr.add_case_run(case=nc)
 
-        return HttpResponseRedirect(reverse('tcms.testruns.views.get',
+        return HttpResponseRedirect(reverse('testruns-get',
                                             args=[tr.run_id, ]))
 
     def get(self, request, run_id):
@@ -1512,7 +1512,7 @@ def update_case_run_text(request, run_id):
         request=request,
         info_type=Prompt.Info,
         info=info,
-        next=reverse('tcms.testruns.views.get', args=[run_id, ]),
+        next=reverse('testruns-get', args=[run_id, ]),
     ))
 
 

--- a/tcms/tests/__init__.py
+++ b/tcms/tests/__init__.py
@@ -5,9 +5,12 @@ from django.contrib.auth.models import Permission
 
 from tcms.tests.factories import ProductFactory
 from tcms.tests.factories import TestCaseFactory
+from tcms.tests.factories import TestCaseRunFactory
 from tcms.tests.factories import TestPlanFactory
+from tcms.tests.factories import TestRunFactory
 from tcms.tests.factories import UserFactory
 from tcms.tests.factories import VersionFactory
+from tcms.tests.factories import TestBuildFactory
 
 __all__ = (
     'user_should_have_perm',
@@ -85,3 +88,36 @@ class BasePlanCase(test.TestCase):
                                      plan=[cls.plan])
         cls.case_3 = TestCaseFactory(author=cls.tester, default_tester=None, reviewer=cls.tester,
                                      plan=[cls.plan])
+
+
+class BaseCaseRun(BasePlanCase):
+    """Base test case containing test run and case runs"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(BaseCaseRun, cls).setUpTestData()
+
+        cls.build = TestBuildFactory(product=cls.product)
+
+        cls.test_run = TestRunFactory(product_version=cls.version,
+                                      plan=cls.plan,
+                                      manager=cls.tester,
+                                      default_tester=cls.tester)
+        cls.case_run_1 = TestCaseRunFactory(assignee=cls.tester,
+                                            tested_by=cls.tester,
+                                            run=cls.test_run,
+                                            case=cls.case_1,
+                                            build=cls.build,
+                                            sortkey=101)
+        cls.case_run_2 = TestCaseRunFactory(assignee=cls.tester,
+                                            tested_by=cls.tester,
+                                            run=cls.test_run,
+                                            case=cls.case_2,
+                                            build=cls.build,
+                                            sortkey=200)
+        cls.case_run_3 = TestCaseRunFactory(assignee=cls.tester,
+                                            tested_by=cls.tester,
+                                            run=cls.test_run,
+                                            case=cls.case_3,
+                                            build=cls.build,
+                                            sortkey=300)

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -39,22 +39,23 @@ urlpatterns = [
     url(r'^xmlrpc/$', xmlrpc_handler),
 
     # Ajax call responder
-    url(r'^ajax/update/$', ajax.update),
+    url(r'^ajax/update/$', ajax.update, name='ajax-update'),
     url(r'^ajax/update/case-status/$', ajax.update_cases_case_status),
-    url(r'^ajax/update/case-run-status$', ajax.update_case_run_status),
+    url(r'^ajax/update/case-run-status$', ajax.update_case_run_status, name='ajax-update_case_run_status'),
     url(r'^ajax/update/cases-priority/$', ajax.update_cases_priority),
-    url(r'^ajax/update/cases-default-tester/$', ajax.update_cases_default_tester),
+    url(r'^ajax/update/cases-default-tester/$', ajax.update_cases_default_tester,
+        name='ajax-update_cases_default_tester'),
     url(r'^ajax/update/cases-reviewer/$', ajax.update_cases_reviewer),
     url(r'^ajax/update/cases-sortkey/$', ajax.update_cases_sortkey),
-    url(r'^ajax/form/$', ajax.form),
+    url(r'^ajax/form/$', ajax.form, name='ajax-form'),
     url(r'^ajax/get-prod-relate-obj/$', ajax.get_prod_related_obj_json),
-    url(r'^management/getinfo/$', ajax.info),
+    url(r'^management/getinfo/$', ajax.info, name='ajax-info'),
     url(r'^management/tags/$', ajax.tag),
 
     # Attached file zone
-    url(r'^management/uploadfile/$', files.upload_file),
-    url(r'^management/checkfile/(?P<file_id>\d+)/$', files.check_file),
-    url(r'^management/deletefile/(?P<file_id>\d+)/$', files.delete_file),
+    url(r'^management/uploadfile/$', files.upload_file, name='mgmt-upload_file'),
+    url(r'^management/checkfile/(?P<file_id>\d+)/$', files.check_file, name='mgmt-check_file'),
+    url(r'^management/deletefile/(?P<file_id>\d+)/$', files.delete_file, name='mgmt-delete_file'),
 
     # comments
     url(r'^comments/post/', comments_views.post),
@@ -77,7 +78,7 @@ urlpatterns = [
 
     url(r'^caseruns/$', testruns_views.caseruns),
     url(r'^caserun/(?P<case_run_id>\d+)/bug/$', testruns_views.bug),
-    url(r'^caserun/comment-many/', ajax.comment_case_runs),
+    url(r'^caserun/comment-many/', ajax.comment_case_runs, name='ajax-comment_case_runs'),
     url(r'^caserun/update-bugs-for-many/', ajax.update_bugs_to_caseruns),
 
     url(r'^linkref/add/$', linkreference_views.add),
@@ -85,10 +86,14 @@ urlpatterns = [
     url(r'^linkref/remove/(?P<link_id>\d+)/$', linkreference_views.remove),
 
     # Management zone
-    url(r'^environment/groups/$', management_views.environment_groups),
-    url(r'^environment/group/edit/$', management_views.environment_group_edit),
-    url(r'^environment/properties/$', management_views.environment_properties),
-    url(r'^environment/properties/values/$', management_views.environment_property_values),
+    url(r'^environment/groups/$', management_views.environment_groups,
+        name='mgmt-environment_groups'),
+    url(r'^environment/group/edit/$', management_views.environment_group_edit,
+        name='mgmt-environment_group_edit'),
+    url(r'^environment/properties/$', management_views.environment_properties,
+        name='mgmt-environment_properties'),
+    url(r'^environment/properties/values/$', management_views.environment_property_values,
+        name='mgmt-environment_property_values'),
 
     # Report zone
     url(r'^report/', include(report_urls)),

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -1,105 +1,122 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
-from django.conf.urls import include, url, patterns
+from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.admindocs import urls as admindocs_urls
+from django.views.i18n import javascript_catalog
+
+from tinymce import urls as tinymce_urls
+from tcms.core import ajax
+from tcms.core import files
+from tcms.core import views as core_views
+from tcms.core.contrib.comments import views as comments_views
+from tcms.core.contrib.linkreference import views as linkreference_views
+from tcms.profiles import urls as profiles_urls
+from tcms.testplans import urls as testplans_urls
+from tcms.testcases import urls as testcases_urls
+from tcms.testruns import urls as testruns_urls
+from tcms.testruns import views as testruns_views
+from tcms.management import views as management_views
+from tcms.report import urls as report_urls
+from tcms.search import advance_search
+
 
 # XML RPC handler
 from kobo.django.xmlrpc.views import XMLRPCHandlerFactory
 xmlrpc_handler = XMLRPCHandlerFactory('TCMS_XML_RPC')
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
 
-    # Uncomment the admin/doc line below and add 'django.contrib.admindocs'
-    # to INSTALLED_APPS to enable admin documentation:
-    (r'^admin/doc/', include('django.contrib.admindocs.urls')),
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/doc/', include(admindocs_urls)),
 
-    (r'^tinymce/', include('tinymce.urls')),
+    url(r'^tinymce/', include(tinymce_urls)),
 
     # Index and static zone
-    (r'^$', 'tcms.core.views.index'),
-    (r'^search/$', 'tcms.core.views.search'),
-    (r'^xmlrpc/$', xmlrpc_handler),
+    url(r'^$', core_views.index, name='core-views-index'),
+    url(r'^search/$', core_views.search, name='core-views-search'),
+    url(r'^xmlrpc/$', xmlrpc_handler),
 
     # Ajax call responder
-    (r'^ajax/update/$', 'tcms.core.ajax.update'),
-    # TODO: merge this into next mapping
-    (r'^ajax/update/case-status/$', 'tcms.core.ajax.update_cases_case_status'),
-    (r'^ajax/update/case-run-status$', 'tcms.core.ajax.update_case_run_status'),
-    (r'^ajax/update/cases-priority/$', 'tcms.core.ajax.update_cases_priority'),
-    (r'^ajax/update/cases-default-tester/$', 'tcms.core.ajax.update_cases_default_tester'),
-    (r'^ajax/update/cases-reviewer/$', 'tcms.core.ajax.update_cases_reviewer'),
-    (r'^ajax/update/cases-sortkey/$', 'tcms.core.ajax.update_cases_sortkey'),
-    (r'^ajax/form/$', 'tcms.core.ajax.form'),
-    (r'^ajax/get-prod-relate-obj/$', 'tcms.core.ajax.get_prod_related_obj_json'),
-    (r'^management/getinfo/$', 'tcms.core.ajax.info'),
-    (r'^management/tags/$', 'tcms.core.ajax.tag'),
+    url(r'^ajax/update/$', ajax.update),
+    url(r'^ajax/update/case-status/$', ajax.update_cases_case_status),
+    url(r'^ajax/update/case-run-status$', ajax.update_case_run_status),
+    url(r'^ajax/update/cases-priority/$', ajax.update_cases_priority),
+    url(r'^ajax/update/cases-default-tester/$', ajax.update_cases_default_tester),
+    url(r'^ajax/update/cases-reviewer/$', ajax.update_cases_reviewer),
+    url(r'^ajax/update/cases-sortkey/$', ajax.update_cases_sortkey),
+    url(r'^ajax/form/$', ajax.form),
+    url(r'^ajax/get-prod-relate-obj/$', ajax.get_prod_related_obj_json),
+    url(r'^management/getinfo/$', ajax.info),
+    url(r'^management/tags/$', ajax.tag),
 
     # Attached file zone
-    (r'^management/uploadfile/$', 'tcms.core.files.upload_file'),
-    (r'^management/checkfile/(?P<file_id>\d+)/$', 'tcms.core.files.check_file'),
-    (r'^management/deletefile/(?P<file_id>\d+)/$', 'tcms.core.files.delete_file'),
+    url(r'^management/uploadfile/$', files.upload_file),
+    url(r'^management/checkfile/(?P<file_id>\d+)/$', files.check_file),
+    url(r'^management/deletefile/(?P<file_id>\d+)/$', files.delete_file),
 
-    (r'^comments/post/', 'tcms.core.contrib.comments.views.post'),
-    (r'^comments/delete/', 'tcms.core.contrib.comments.views.delete'),
+    # comments
+    url(r'^comments/post/', comments_views.post),
+    url(r'^comments/delete/', comments_views.delete),
 
     # Account information zone, such as login method
-    url(r'^accounts/', include('tcms.profiles.urls')),
+    url(r'^accounts/', include(profiles_urls)),
 
     # Testplans zone
-    url(r'^plan/', include('tcms.testplans.urls.plan_urls')),
-    url(r'^plans/', include('tcms.testplans.urls.plans_urls')),
+    url(r'^plan/', include(testplans_urls.plan_urls)),
+    url(r'^plans/', include(testplans_urls.plans_urls)),
 
     # Testcases zone
-    url(r'^case/', include('tcms.testcases.urls.case_urls')),
-    url(r'^cases/', include('tcms.testcases.urls.cases_urls')),
+    url(r'^case/', include(testcases_urls.case_urls)),
+    url(r'^cases/', include(testcases_urls.cases_urls)),
 
     # Testruns zone
-    url(r'^run/', include('tcms.testruns.urls.run_urls')),
-    url(r'^runs/', include('tcms.testruns.urls.runs_urls')),
+    url(r'^run/', include(testruns_urls.run_urls)),
+    url(r'^runs/', include(testruns_urls.runs_urls)),
 
-    (r'^caseruns/$', 'tcms.testruns.views.caseruns'),
-    (r'^caserun/(?P<case_run_id>\d+)/bug/$', 'tcms.testruns.views.bug'),
-    (r'^caserun/comment-many/', 'tcms.core.ajax.comment_case_runs'),
-    (r'^caserun/update-bugs-for-many/', 'tcms.core.ajax.update_bugs_to_caseruns'),
+    url(r'^caseruns/$', testruns_views.caseruns),
+    url(r'^caserun/(?P<case_run_id>\d+)/bug/$', testruns_views.bug),
+    url(r'^caserun/comment-many/', ajax.comment_case_runs),
+    url(r'^caserun/update-bugs-for-many/', ajax.update_bugs_to_caseruns),
 
-    (r'^linkref/add/$', 'tcms.core.contrib.linkreference.views.add'),
-    (r'^linkref/get/$', 'tcms.core.contrib.linkreference.views.get'),
-    (r'^linkref/remove/(?P<link_id>\d+)/$', 'tcms.core.contrib.linkreference.views.remove'),
+    url(r'^linkref/add/$', linkreference_views.add),
+    url(r'^linkref/get/$', linkreference_views.get),
+    url(r'^linkref/remove/(?P<link_id>\d+)/$', linkreference_views.remove),
 
     # Management zone
-    # (r'^management/$', 'tcms.management.views.index'),
-    (r'^environment/groups/$', 'tcms.management.views.environment_groups'),
-    (r'^environment/group/edit/$', 'tcms.management.views.environment_group_edit'),
-    (r'^environment/properties/$', 'tcms.management.views.environment_properties'),
-    (r'^environment/properties/values/$', 'tcms.management.views.environment_property_values'),
-
-    # Management ajax zone
+    url(r'^environment/groups/$', management_views.environment_groups),
+    url(r'^environment/group/edit/$', management_views.environment_group_edit),
+    url(r'^environment/properties/$', management_views.environment_properties),
+    url(r'^environment/properties/values/$', management_views.environment_property_values),
 
     # Report zone
-    url(r'^report/', include('tcms.report.urls')),
+    url(r'^report/', include(report_urls)),
 
     # Advance search
-    url(r'^advance-search/$', 'tcms.search.advance_search', name='advance_search'),
+    url(r'^advance-search/$', advance_search, name='advance_search'),
 
+    # TODO: do we need this at all ???
     # Using admin js without admin permission
-    # refer: https://docs.djangoproject.com/en/1.6/topics/i18n/translation/#module-django.views.i18n
-    (r'^jsi18n/$', 'django.views.i18n.javascript_catalog',
-     {'packages': ('django.conf', 'django.contrib.admin')}),
-)
+    # https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#django.views.i18n.javascript_catalog
+    url(r'^jsi18n/$', javascript_catalog, {'packages': ('django.conf', 'django.contrib.admin')}),
+]
 
 # Debug zone
 
 if settings.DEBUG:
-    import debug_toolbar
-    urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
-    ]
-    urlpatterns += patterns(
-        'tcms.core.utils.test_template',
-        (r'^tt/(?P<template_name>.*)', 'test_template'),
-    )
+    try:
+        import debug_toolbar
+        from tcms.core.utils import test_template
+
+        urlpatterns += [
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+            url(r'^tt/(?P<template_name>.*)', test_template),
+        ]
+    # in case we're trying to debug in production
+    # and debug_toolbar is not installed
+    except ImportError:
+        pass
 
 # Overwrite default 500 handler
 # More details could see django.core.urlresolvers._resolve_special()

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -116,7 +116,7 @@ if settings.DEBUG:
 
         urlpatterns += [
             url(r'^__debug__/', include(debug_toolbar.urls)),
-            url(r'^tt/(?P<template_name>.*)', test_template),
+            url(r'^tt/(?P<template_name>.*)', test_template.test_template),
         ]
     # in case we're trying to debug in production
     # and debug_toolbar is not installed

--- a/tcms/xmlrpc/tests/test_product.py
+++ b/tcms/xmlrpc/tests/test_product.py
@@ -207,7 +207,9 @@ class TestFilterVersions(TestCase):
         versions = product.filter_versions(None, {'product_id': self.product.pk})
         self.assertIsInstance(versions, list)
         versions = [version['value'] for version in versions]
-        self.assertEqual(['0.7', 'unspecified'], versions)
+        self.assertEqual(2, len(versions))
+        self.assertIn('0.7', versions)
+        self.assertIn('unspecified', versions)
 
     def test_filter_by_name(self):
         ver = product.filter_versions(None, {'value': '0.7'})


### PR DESCRIPTION
- picked PR #206 and #207 from original repo before the fork which remove some instances of deprecated `request.REQUEST` and add more tests
- don't use string based views anymore b/c they are deprecated
- don't reverse URLs by dotted path b/c deprecated (adds url names where necessary)
- couple more fixes for deprecated settings and classes
- Fixed failing build #8 and #9 in Travis CI