### PR TITLE
Refactor datatable response

### DIFF
--- a/tcms/core/utils/__init__.py
+++ b/tcms/core/utils/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+from django.conf import settings
 
 numeric_re = re.compile(r'^\d+$')
 
@@ -123,3 +124,56 @@ class QuerySetIterationProxy(object):
                         getattr(next_one, self._associate_name, None),
                         ()))
         return next_one
+
+
+class DataTableResult(object):
+    """Paginate and order queryset for rendering DataTable response"""
+
+    def __init__(self, request_data, queryset, column_names):
+        self.queryset = queryset
+        self.request_data = request_data
+        self.column_names = column_names
+
+    def _iter_sorting_columns(self):
+        number_of_sorting_cols = int(self.request_data.get('iSortingCols', 0))
+        for idx_which_column in range(number_of_sorting_cols):
+            sorting_col_index = int(
+                self.request_data.get('iSortCol_{}'.format(idx_which_column),
+                                      0))
+
+            sortable_key = 'bSortable_{}'.format(sorting_col_index)
+            sort_dir_key = 'sSortDir_{}'.format(idx_which_column)
+
+            sortable = self.request_data.get(sortable_key, 'false')
+            if sortable == 'false':
+                continue
+
+            sorting_col_name = self.column_names[sorting_col_index]
+            sorting_direction = self.request_data.get(sort_dir_key, 'asc')
+            yield sorting_col_name, sorting_direction
+
+    def _sort_result(self):
+        sorting_columns = self._iter_sorting_columns()
+        order_fields = ['-{}'.format(col_name) if direction == 'desc' else col_name
+                        for col_name, direction in sorting_columns]
+        if order_fields:
+            self.queryset = self.queryset.order_by(*order_fields)
+
+    def _paginate_result(self):
+        display_length = int(self.request_data.get('iDisplayLength', settings.DEFAULT_PAGE_SIZE))
+        display_start = int(self.request_data.get('iDisplayStart', 0))
+        display_end = display_start + display_length
+        self.queryset = self.queryset[display_start:display_end]
+
+    def get_response_data(self):
+        total_records = total_display_records = self.queryset.count()
+
+        self._sort_result()
+        self._paginate_result()
+
+        return {
+            'sEcho': int(self.request_data.get('sEcho', 0)),
+            'iTotalRecords': total_records,
+            'iTotalDisplayRecords': total_display_records,
+            'querySet': self.queryset,
+        }

--- a/tcms/templates/plan/common/json_plan_runs.txt
+++ b/tcms/templates/plan/common/json_plan_runs.txt
@@ -3,7 +3,7 @@
 	"iTotalRecords": {{iTotalRecords}},
 	"iTotalDisplayRecords": {{iTotalDisplayRecords}},
 	"aaData": [
-		{% for run in runs %}
+		{% for run in querySet %}
 		[
 			"<input type='checkbox' name='run' value='{{ run.pk }}' class='run_selector'>",
 			"<a href='{% url "testruns-get" run.run_id %}' >{{ run.run_id }}</a>",

--- a/tcms/templates/run/common/json_runs.txt
+++ b/tcms/templates/run/common/json_runs.txt
@@ -3,7 +3,7 @@
 	"iTotalRecords": {{ iTotalRecords }},
 	"iTotalDisplayRecords": {{ iTotalDisplayRecords }},
 	"aaData":[
-	{% for run in runs %}
+	{% for run in querySet %}
 	[
 		"<input type='checkbox' name='run' value='{{  run.pk  }}' class='run_selector'>",
 		"<a href='{% url "testruns-get" run.run_id %}'>{{  run.run_id  }}</a>",

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -24,6 +24,7 @@ from tcms.core import forms
 from tcms.core.logs.models import TCMSLogModel
 from tcms.core.responses import HttpJSONResponse
 from tcms.core.utils.raw_sql import RawSQL
+from tcms.core.utils import DataTableResult
 from tcms.core.views import Prompt
 from tcms.search import remove_from_request_path
 from tcms.search.order import order_case_queryset
@@ -699,95 +700,33 @@ def ajax_search(request, template_name='case/common/json_cases.txt'):
 
     # columnIndexNameMap is required for correct sorting behavior, 5 should be
     # product, but we use run.build.product
-    columnIndexNameMap = {
-        0: '', 1: '', 2: 'case_id',
-        3: 'summary', 4: 'author__username',
-        5: 'default_tester__username', 6: 'is_automated',
-        7: 'case_status__name', 8: 'category__name',
-        9: 'priority__value', 10: 'create_date'
-    }
-    return ajax_response(request, tcs, tp, columnIndexNameMap,
-                         jsonTemplatePath='case/common/json_cases.txt')
+    column_names = [
+        '',
+        '',
+        'case_id',
+        'summary',
+        'author__username',
+        'default_tester__username',
+        'is_automated',
+        'case_status__name',
+        'category__name',
+        'priority__value',
+        'create_date',
+    ]
+    return ajax_response(request, tcs, column_names, template_name)
 
 
-def ajax_response(request, querySet, testplan, columnIndexNameMap,
-                  jsonTemplatePath='case/common/json_cases.txt', *args):
-    """
-    json template for the ajax request for searching.
-    """
-    # Get the number of columns
-    cols = int(request.GET.get('iColumns', 0))
-    # Safety measure. If someone messes with iDisplayLength manually,
-    # we clip it to the max value of 100.
-    iDisplayLength = min(int(request.GET.get('iDisplayLength', 20)), 100)
-    # Where the data starts from (page)
-    startRecord = int(request.GET.get('iDisplayStart', 0))
-    # where the data ends (end of page)
-    endRecord = startRecord + iDisplayLength
+def ajax_response(request, queryset, column_names, template_name):
+    """json template for the ajax request for searching"""
+    dt = DataTableResult(request.GET, queryset, column_names)
 
-    # Pass sColumns
-    keys = columnIndexNameMap.keys()
-    keys.sort()
-    colitems = [columnIndexNameMap[key] for key in keys]
-    sColumns = ",".join(map(str, colitems))
-
-    # Ordering data
-    iSortingCols = int(request.GET.get('iSortingCols', 0))
-    asortingCols = []
-
-    if iSortingCols:
-        for sortedColIndex in range(0, iSortingCols):
-            sortedColID = int(
-                request.GET.get('iSortCol_' + str(sortedColIndex), 0))
-            # make sure the column is sortable first
-            if request.GET.get('bSortable_%s' % sortedColID,
-                               'false') == 'true':
-                sortedColName = columnIndexNameMap[sortedColID]
-                sortingDirection = request.GET.get(
-                    'sSortDir_' + str(sortedColIndex), 'asc')
-                if sortingDirection == 'desc':
-                    sortedColName = '-' + sortedColName
-                asortingCols.append(sortedColName)
-        if len(asortingCols):
-            querySet = querySet.order_by(*asortingCols)
-
-    # count how many records match the final criteria
-    iTotalRecords = iTotalDisplayRecords = querySet.count()
-    # get the slice
-    querySet = querySet[startRecord:endRecord]
-
-    sEcho = int(request.GET.get('sEcho', 0))  # required echo response
-
-    if jsonTemplatePath:
-        try:
-            # prepare the JSON with the response, consider using :
-            # from django.template.defaultfilters import escapejs
-            jsonString = render_to_string(jsonTemplatePath, locals(), request=request)
-            response = HttpJSONResponse(jsonString)
-        except Exception as e:
-            print e
-    else:
-        aaData = []
-        a = querySet.values()
-        for row in a:
-            rowkeys = row.keys()
-            rowvalues = row.values()
-            rowlist = []
-            for col in range(0, len(colitems)):
-                for idx, val in enumerate(rowkeys):
-                    if val == colitems[col]:
-                        rowlist.append(str(rowvalues[idx]))
-            aaData.append(rowlist)
-            response_dict = {}
-            response_dict.update({'aaData': aaData})
-            response_dict.update(
-                {'sEcho': sEcho, 'iTotalRecords': iTotalRecords,
-                 'iTotalDisplayRecords': iTotalDisplayRecords,
-                 'sColumns': sColumns})
-            response = HttpJSONResponse(json.dumps(response_dict))
-            # prevent from caching datatables result
-            #    add_never_cache_headers(response)
-    return response
+    # prepare the JSON with the response, consider using :
+    # from django.template.defaultfilters import escapejs
+    json_result = render_to_string(
+        template_name,
+        dt.get_response_data(),
+        request=request)
+    return HttpJSONResponse(json_result)
 
 
 class SimpleTestCaseView(TemplateView, data.TestCaseViewDataMixin):

--- a/tcms/testplans/tests.py
+++ b/tcms/testplans/tests.py
@@ -778,3 +778,121 @@ class TestCloneView(BasePlanCase):
         for origin_plan in (self.plan, self.another_plan):
             cloned_plan = TestPlan.objects.get(name=origin_plan.make_cloned_name())
             self.verify_cloned_plan(origin_plan, cloned_plan)
+
+
+class TestAJAXSearch(BasePlanCase):
+    """Test ajax_search view method"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TestAJAXSearch, cls).setUpTestData()
+
+        # Add more plans for testing search
+        for i in range(25):
+            TestPlanFactory(author=cls.tester,
+                            owner=cls.tester,
+                            product=cls.product,
+                            product_version=cls.version)
+
+        # So far, each test has 26 plans
+
+        cls.search_url = reverse('plans-ajax_search')
+
+        # By default, search active plans. Search by other fields if needed,
+        # copy this dict and add other fields.
+        cls.search_data = {
+            # Search plans
+            'is_active': 'on',
+
+            # DataTable properties: pagination and sorting
+            'sEcho': 1,
+            'iDisplayStart': 0,
+            'iDisplayLength': 3,
+            'iSortCol_0': 1,
+            'sSortDir_0': 'asc',
+            'iSortingCols': 1,
+            # In the view, first column is not sortable.
+            'bSortable_0': 'false',
+            'bSortable_1': 'true',
+            'bSortable_2': 'true',
+            'bSortable_3': 'true',
+            'bSortable_4': 'true',
+        }
+
+    def test_emtpy_plans(self):
+        response = self.client.get(self.search_url, {})
+
+        data = json.loads(response.content)
+
+        self.assertEqual(0, data['sEcho'])
+        self.assertEqual(0, data['iTotalRecords'])
+        self.assertEqual(0, data['iTotalDisplayRecords'])
+        self.assertEqual([], data['aaData'])
+
+    def test_get_first_page_order_by_pk(self):
+        search_data = self.search_data.copy()
+
+        response = self.client.get(self.search_url, search_data)
+
+        data = json.loads(response.content)
+
+        plans_count = TestPlan.objects.count()
+        self.assertEqual(1, data['sEcho'])
+        self.assertEqual(plans_count, data['iTotalRecords'])
+        self.assertEqual(plans_count, data['iTotalDisplayRecords'])
+        self.assertEqual(search_data['iDisplayLength'], len(data['aaData']))
+
+        expected_plans = TestPlan.objects.all()[0:3]
+
+        for i, plan in enumerate(expected_plans):
+            self.assertEquals(
+                "<a href='{}'>{}</a>".format(plan.get_absolute_url(), plan.pk),
+                data['aaData'][i]['1'])
+
+    def test_get_last_page_order_by_name(self):
+        search_data = self.search_data.copy()
+        plans_count = TestPlan.objects.count()
+        # To request last page
+        search_data['iDisplayStart'] = plans_count / 3 * 3
+        search_data['iSortCol_0'] = 2
+
+        response = self.client.get(self.search_url, search_data)
+
+        data = json.loads(response.content)
+
+        self.assertEqual(1, data['sEcho'])
+        self.assertEqual(plans_count, data['iTotalRecords'])
+        self.assertEqual(plans_count, data['iTotalDisplayRecords'])
+        self.assertEqual(2, len(data['aaData']))
+
+        expected_plans = TestPlan.objects.order_by('name')[
+            search_data['iDisplayStart']:plans_count
+        ]
+
+        for i, plan in enumerate(expected_plans):
+            self.assertEquals(
+                "<a href='{}'>{}</a>".format(plan.get_absolute_url(), plan.pk),
+                data['aaData'][i]['1'])
+
+    def test_get_second_page_order_by_pk_desc(self):
+        search_data = self.search_data.copy()
+        # To request second page
+        search_data['iDisplayStart'] = 3
+        search_data['sSortDir_0'] = 'desc'
+
+        response = self.client.get(self.search_url, search_data)
+
+        data = json.loads(response.content)
+
+        plans_count = TestPlan.objects.count()
+        self.assertEqual(1, data['sEcho'])
+        self.assertEqual(plans_count, data['iTotalRecords'])
+        self.assertEqual(plans_count, data['iTotalDisplayRecords'])
+        self.assertEqual(search_data['iDisplayLength'], len(data['aaData']))
+
+        expected_plans = TestPlan.objects.order_by('-pk')[3:6]
+
+        for i, plan in enumerate(expected_plans):
+            self.assertEquals(
+                "<a href='{}'>{}</a>".format(plan.get_absolute_url(), plan.pk),
+                data['aaData'][i]['1'])

--- a/tcms/testplans/urls/plans_urls.py
+++ b/tcms/testplans/urls/plans_urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     url(r'^$', views.all, name='testplans-all'),
 
     url(r'^new/$', views.new, name='plans-new'),
-    url(r'^ajax/$', views.ajax_search),
+    url(r'^ajax/$', views.ajax_search, name='plans-ajax_search'),
     url(r'^treeview/$', views.tree_view),
     url(r'^clone/$', views.clone, name='plans-clone'),
     url(r'^printable/$', views.printable, name='plans-printable'),

--- a/tcms/testruns/tests/test_views.py
+++ b/tcms/testruns/tests/test_views.py
@@ -658,6 +658,33 @@ class TestAJAXSearchRuns(BaseCaseRun):
             default_tester=cls.run_tester,
             tag=[TestTagFactory(name='rhel')])
 
+        cls.search_data = {
+            'action': 'search',
+            # Add criteria for searching runs in each test
+
+            # DataTable properties: pagination and sorting
+            'sEcho': 1,
+            'iDisplayStart': 0,
+            # Make enough length to display all searched runs in one page
+            'iDisplayLength': TestRun.objects.count() + 1,
+            'iSortCol_0': 1,
+            'sSortDir_0': 'asc',
+            'iSortingCols': 1,
+            # In the view, first column is not sortable.
+            'bSortable_0': 'false',
+            'bSortable_1': 'true',
+            'bSortable_2': 'true',
+            'bSortable_3': 'true',
+            'bSortable_4': 'true',
+            'bSortable_5': 'true',
+            'bSortable_6': 'true',
+            'bSortable_7': 'true',
+            'bSortable_8': 'true',
+            'bSortable_9': 'true',
+            'bSortable_10': 'true',
+            'bSortable_11': 'true',
+        }
+
     def assert_found_runs(self, expected_found_runs, search_result):
         expected_runs_count = len(expected_found_runs)
         self.assertEqual(expected_runs_count, search_result['iTotalRecords'])


### PR DESCRIPTION
New DataTableResult is introduced to handle search objects pagination
and sorting for generating response data for rendering in DataTable in
user's web browser.

Search plans, cases, runs and runs in plan page are modified to use this
new class.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

Conflicts:
	tcms/testcases/views.py
	tcms/testplans/views.py
	tcms/testruns/views.py